### PR TITLE
Improve reproducibility debug logs: include sample IDs, valid_ratio and top-label summaries

### DIFF
--- a/config.py
+++ b/config.py
@@ -317,6 +317,9 @@ _C.THROUGHPUT_MODE = False
 _C.LOCAL_RANK = 0
 # for acceleration
 _C.FUSED_WINDOW_PROCESS = False
+
+# Debug / reproducibility diagnostics
+_C.DEBUG_REPRO_STEPS = 0
 _C.FUSED_LAYERNORM = False
 _C.SKIP_INITIAL_EVAL = False
 _C.MODEL.DECODER_DOWNSAMPLER = True
@@ -475,6 +478,9 @@ def update_config(config, args):
         config.SEED = args.seed
     if _check_args('deterministic'):
         config.DETERMINISTIC = True
+
+    if _check_args('debug_repro_steps'):
+        config.DEBUG_REPRO_STEPS = int(args.debug_repro_steps)
 
        # [SimMIM]
     if _check_args('enable_amp'):


### PR DESCRIPTION
### Motivation

- Surface richer per-batch diagnostics to help diagnose cross-GPU training divergences observed between cards (different sample ordering, ignore-mask differences, or class-distribution skew). 
- The existing debug log printed only sample mean/std and target/output mean/std which can hide label-ignore ratio and class composition differences.

### Description

- Add a new config field `DEBUG_REPRO_STEPS` and a CLI flag `--debug-repro-steps` so the first N train steps per epoch can emit enhanced diagnostics via the config/arg parsing paths (`config.py` and `parse_option()` in `main.py`).
- Enhance the training debug logger inside `train_one_epoch` to include the first few sample IDs from `batch['meta']['image']` (as `ids=`) so batches across devices can be compared.
- Compute per-task `valid_ratio` (fraction of labels != 255) for targets and, for `semseg` and `human_parts`, emit a compact `top_labels` summary listing up to the top-3 label:id:count pairs; these are concatenated into `target_stats` for the debug line.
- Add compact runtime startup info to the logger including `torch`, `cuda`, `cudnn`, device name, `amp`, `deterministic`, TF32 flags and the `debug_repro_steps` value to aid reproducibility troubleshooting.

### Testing

- Ran Python byte-compile checks with `python -m py_compile main.py config.py` which completed successfully.
- No other automated test suites were available or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995335c5ecc832587399553d128e524)