### PR TITLE
Improve repro_diagnose script: dataset-root safeguards, train-cmd parsing, and quick findings

### DIFF
--- a/scripts/repro_diagnose.py
+++ b/scripts/repro_diagnose.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+One-shot reproducibility diagnosis for MT-LoRA PASCAL_MT runs.
+
+Usage example:
+  python scripts/repro_diagnose.py \
+    --pascal-root /path/to/PASCAL_MT \
+    --output reports/repro_diag_a100.json
+
+Run on both servers and compare JSON outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shlex
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+DEFAULT_IDS = [
+    "2008_005016",
+    "2009_004797",
+    "2008_006355",
+    "2008_003209",
+    "2009_002629",
+    "2008_006960",
+    "2008_006973",
+    "2009_000636",
+]
+
+
+def run_cmd(cmd: List[str]) -> Dict[str, object]:
+    try:
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        return {
+            "cmd": " ".join(cmd),
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+    except Exception as exc:  # pragma: no cover
+        return {"cmd": " ".join(cmd), "error": repr(exc)}
+
+
+def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> Optional[str]:
+    if not path.is_file():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def safe_import_version(module_name: str) -> Dict[str, Optional[str]]:
+    out = {"module": module_name, "version": None, "error": None}
+    try:
+        module = __import__(module_name)
+        out["version"] = getattr(module, "__version__", "<no __version__>")
+    except Exception as exc:
+        out["error"] = repr(exc)
+    return out
+
+
+def infer_semseg_path(root: Path, image_id: str) -> Tuple[Optional[Path], str]:
+    voc = root / "semseg" / "VOC12" / f"{image_id}.png"
+    ctx = root / "semseg" / "pascal-context" / f"{image_id}.png"
+    if voc.is_file():
+        return voc, "VOC12"
+    if ctx.is_file():
+        return ctx, "pascal-context"
+    return None, "missing"
+
+
+def read_ids(ids_arg: Optional[str]) -> List[str]:
+    if not ids_arg:
+        return DEFAULT_IDS
+    p = Path(ids_arg)
+    if p.is_file():
+        ids: List[str] = []
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                ids.append(line)
+        return ids
+    return [x.strip() for x in ids_arg.split(",") if x.strip()]
+
+
+def tree_manifest_hash(root: Path) -> Dict[str, object]:
+    if not root.exists():
+        return {"exists": False}
+    rel_paths: List[str] = []
+    file_count = 0
+    dir_count = 0
+    for dpath, dnames, fnames in os.walk(root):
+        dir_count += len(dnames)
+        for fn in fnames:
+            file_count += 1
+            full = Path(dpath) / fn
+            rel_paths.append(str(full.relative_to(root)))
+    rel_paths.sort()
+    h = hashlib.sha256()
+    for rp in rel_paths:
+        h.update(rp.encode("utf-8"))
+        h.update(b"\n")
+    return {
+        "exists": True,
+        "file_count": file_count,
+        "dir_count": dir_count,
+        "pathlist_sha256": h.hexdigest(),
+    }
+
+
+def filelist_content_hash(root: Path) -> Dict[str, object]:
+    if not root.exists():
+        return {"exists": False}
+    h = hashlib.sha256()
+    file_count = 0
+    total_bytes = 0
+    for dpath, _, fnames in os.walk(root):
+        for fn in sorted(fnames):
+            file_count += 1
+            fp = Path(dpath) / fn
+            rel = str(fp.relative_to(root))
+            h.update(rel.encode("utf-8"))
+            h.update(b"\0")
+            st = fp.stat()
+            total_bytes += st.st_size
+            h.update(str(st.st_size).encode("utf-8"))
+            h.update(b"\0")
+            fh = sha256_file(fp)
+            h.update((fh or "MISSING").encode("utf-8"))
+            h.update(b"\n")
+    return {
+        "exists": True,
+        "file_count": file_count,
+        "total_bytes": total_bytes,
+        "content_sha256": h.hexdigest(),
+    }
+
+
+def collect_env() -> Dict[str, object]:
+    env_keys = [
+        "CUDA_VISIBLE_DEVICES",
+        "CUBLAS_WORKSPACE_CONFIG",
+        "PYTHONHASHSEED",
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NCCL_DEBUG",
+        "NCCL_P2P_DISABLE",
+        "NCCL_IB_DISABLE",
+    ]
+    env = {k: os.environ.get(k) for k in env_keys}
+    versions = [
+        safe_import_version("torch"),
+        safe_import_version("torchvision"),
+        safe_import_version("numpy"),
+        safe_import_version("cv2"),
+        safe_import_version("PIL"),
+        safe_import_version("scipy"),
+        safe_import_version("timm"),
+    ]
+
+    torch_details: Dict[str, object] = {}
+    try:
+        import torch
+        torch_details = {
+            "cuda_available": torch.cuda.is_available(),
+            "cuda_version": torch.version.cuda,
+            "cudnn_version": torch.backends.cudnn.version(),
+            "device_count": torch.cuda.device_count(),
+            "device_names": [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())],
+            "allow_tf32_matmul": torch.backends.cuda.matmul.allow_tf32,
+            "allow_tf32_cudnn": torch.backends.cudnn.allow_tf32,
+            "float32_matmul_precision": torch.get_float32_matmul_precision(),
+        }
+    except Exception as exc:
+        torch_details = {"error": repr(exc)}
+
+    return {
+        "host": socket.gethostname(),
+        "platform": platform.platform(),
+        "python": sys.version,
+        "env": env,
+        "versions": versions,
+        "torch_details": torch_details,
+        "nvidia_smi": run_cmd(["nvidia-smi"]),
+        "pip_freeze": run_cmd([sys.executable, "-m", "pip", "freeze"]),
+    }
+
+
+def collect_dataset(root: Path, ids: List[str], include_full_hash: bool) -> Dict[str, object]:
+    key_dirs = [
+        "JPEGImages",
+        "semseg/VOC12",
+        "semseg/pascal-context",
+        "normals_distill",
+        "sal_distill",
+        "human_parts",
+        "ImageSets/Context",
+        "ImageSets/Parts",
+    ]
+
+    dir_stats = {}
+    for kd in key_dirs:
+        p = root / kd
+        exists = p.exists()
+        count = 0
+        if exists and p.is_dir():
+            count = sum(1 for _ in p.iterdir())
+        dir_stats[kd] = {"exists": exists, "entries": count}
+
+    split_files = [
+        root / "ImageSets" / "Context" / "train.txt",
+        root / "ImageSets" / "Context" / "val.txt",
+        root / "ImageSets" / "Parts" / "trainval.txt",
+    ]
+    split_info = {}
+    for sf in split_files:
+        split_info[str(sf.relative_to(root))] = {
+            "exists": sf.is_file(),
+            "sha256": sha256_file(sf),
+            "line_count": len(sf.read_text(encoding="utf-8").splitlines()) if sf.is_file() else None,
+        }
+
+    parts_cache = root / "ImageSets" / "Parts" / "trainval.txt"
+
+    per_id = {}
+    for image_id in ids:
+        image_path = root / "JPEGImages" / f"{image_id}.jpg"
+        semseg_path, semseg_source = infer_semseg_path(root, image_id)
+        normals_path = root / "normals_distill" / f"{image_id}.png"
+        sal_path = root / "sal_distill" / f"{image_id}.png"
+        human_parts_path = root / "human_parts" / f"{image_id}.mat"
+
+        per_id[image_id] = {
+            "image": {"path": str(image_path), "exists": image_path.is_file(), "sha256": sha256_file(image_path)},
+            "semseg": {
+                "source": semseg_source,
+                "path": str(semseg_path) if semseg_path else None,
+                "exists": semseg_path.is_file() if semseg_path else False,
+                "sha256": sha256_file(semseg_path) if semseg_path else None,
+            },
+            "normals_distill": {"path": str(normals_path), "exists": normals_path.is_file(), "sha256": sha256_file(normals_path)},
+            "sal_distill": {"path": str(sal_path), "exists": sal_path.is_file(), "sha256": sha256_file(sal_path)},
+            "human_parts": {"path": str(human_parts_path), "exists": human_parts_path.is_file(), "sha256": sha256_file(human_parts_path)},
+        }
+
+    out = {
+        "root": str(root),
+        "root_exists": root.exists(),
+        "root_manifest": tree_manifest_hash(root),
+        "key_dirs": dir_stats,
+        "split_files": split_info,
+        "parts_cache_trainval_txt": {"path": str(parts_cache), "exists": parts_cache.is_file(), "sha256": sha256_file(parts_cache)},
+        "per_id": per_id,
+    }
+
+    if include_full_hash:
+        out["full_content_hash"] = filelist_content_hash(root)
+
+    return out
+
+
+def parse_root_from_train_cmd(train_cmd: str) -> Optional[str]:
+    """Parse dataset root from a full training command string."""
+    toks = shlex.split(train_cmd)
+    for i, t in enumerate(toks):
+        if t in {"--pascal", "--data-path", "--nyud"} and i + 1 < len(toks):
+            return toks[i + 1]
+        # also support --pascal=/path style
+        if t.startswith("--pascal="):
+            return t.split("=", 1)[1]
+        if t.startswith("--data-path="):
+            return t.split("=", 1)[1]
+        if t.startswith("--nyud="):
+            return t.split("=", 1)[1]
+    return None
+
+
+def build_quick_findings(report: Dict[str, object]) -> List[str]:
+    findings: List[str] = []
+    ds = report.get("dataset", {})
+    env = report.get("env", {})
+    versions = {v.get("module"): v.get("version") for v in env.get("versions", []) if isinstance(v, dict)}
+
+    if not ds.get("root_exists"):
+        findings.append("[FAIL] dataset root does not exist; dataset hash/label checks are invalid")
+
+    cv2_ver = versions.get("cv2")
+    if cv2_ver:
+        findings.append(f"[INFO] cv2 version: {cv2_ver}")
+
+    td = env.get("torch_details", {})
+    if isinstance(td, dict):
+        if td.get("allow_tf32_matmul") is True:
+            findings.append("[WARN] allow_tf32_matmul=True (for strict reproducibility usually set False)")
+        if td.get("allow_tf32_cudnn") is True:
+            findings.append("[WARN] allow_tf32_cudnn=True (for strict reproducibility usually set False)")
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diagnose cross-server reproducibility issues for MT-LoRA")
+    parser.add_argument("--pascal-root", default=None, help="Path to PASCAL_MT root")
+    parser.add_argument("--train-cmd", default=None, help="Full training command; script auto-parses --pascal/--data-path")
+    parser.add_argument("--ids", default=None, help="Comma-separated ids OR a text file containing one id per line")
+    parser.add_argument("--full-hash", action="store_true", help="Compute full content hash of the dataset root (slow)")
+    parser.add_argument("--allow-missing-root", action="store_true", help="Do not fail when dataset root does not exist")
+    parser.add_argument("--print-summary", action="store_true", help="Print quick findings to stdout")
+    parser.add_argument("--output", default=None, help="Output JSON path. Default: reports/repro_diag_<host>_<ts>.json")
+    args = parser.parse_args()
+
+    ids = read_ids(args.ids)
+
+    resolved_root = args.pascal_root
+    if not resolved_root and args.train_cmd:
+        resolved_root = parse_root_from_train_cmd(args.train_cmd)
+
+    if not resolved_root:
+        print("[error] please provide --pascal-root or --train-cmd", file=sys.stderr)
+        return 2
+
+    pascal_root = Path(resolved_root).expanduser().resolve()
+
+    if not pascal_root.exists() and not args.allow_missing_root:
+        print(
+            f"[error] dataset root not found: {pascal_root}\n"
+            "Hint: pass the real path used by training, e.g. --pascal-root /abs/path/to/PASCAL_MT "
+            "or --train-cmd '... --pascal /abs/path/to/PASCAL_MT ...'\n"
+            "If you intentionally only want env info, add --allow-missing-root.",
+            file=sys.stderr,
+        )
+        return 2
+
+    report = {
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()),
+        "ids": ids,
+        "env": collect_env(),
+        "dataset": collect_dataset(pascal_root, ids, include_full_hash=args.full_hash),
+        "how_to_compare": [
+            "Run this script on both servers.",
+            "Diff JSON files directly, focusing on env.versions, env.torch_details, dataset.split_files, dataset.per_id.",
+            "Any mismatch in per_id hashes or semseg source implies data/label pipeline mismatch.",
+        ],
+    }
+    report["quick_findings"] = build_quick_findings(report)
+
+    output = args.output
+    if not output:
+        host = socket.gethostname().replace("/", "_")
+        ts = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+        output = f"reports/repro_diag_{host}_{ts}.json"
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"[ok] report written to: {output_path}")
+    if args.print_summary:
+        print("[summary]")
+        for line in report["quick_findings"]:
+            print(" -", line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Prevent misleading reports when a placeholder or missing dataset root (e.g. `/path/to/PASCAL_MT`) is supplied, which previously produced JSON that looked complete but contained no real dataset checks.
- Make it easier to run diagnostics from the exact training command by extracting the dataset path automatically from a full `train` command string.
- Provide a short, immediate summary of high-risk differences (TF32, OpenCV version, missing root) to speed triage.

### Description
- Updated `scripts/repro_diagnose.py` to add robust dataset-root handling: `--pascal-root` is now optional if `--train-cmd` is provided and the script fail-fast with a clear error and remediation hint when the root does not exist (unless `--allow-missing-root` is passed).
- Added `--train-cmd` parsing using `shlex` to extract `--pascal`, `--data-path`, or `--nyud` from a full training command string so users can paste their exact launch command.
- Added `quick_findings` generation written into the JSON and exposed via `--print-summary`, producing immediate checks such as missing-root, `cv2` version info, and TF32-related warnings.
- Misc: small CLI improvements (`--allow-missing-root`, `--print-summary`, `--full-hash` support preserved) and defensive/path-hashing helpers retained/improved to avoid false confidence in reports.

### Testing
- Ran `python scripts/repro_diagnose.py --help` and confirmed CLI help printed successfully.
- Ran `python scripts/repro_diagnose.py --pascal-root /path/to/PASCAL_MT --output /tmp/repro_diag_should_fail.json` and confirmed the script exits with an error and exit code `2` when the dataset root is missing (expected behavior).
- Ran `python scripts/repro_diagnose.py --train-cmd "... --pascal /path/to/PASCAL_MT ..." --allow-missing-root --print-summary --output /tmp/repro_diag_from_cmd.json` and confirmed a JSON report was produced and `quick_findings` printed; checks for `root_exists` and `cv2 version` were present.
- Verified report contents via `rg` to ensure `quick_findings`, `root_exists`, and version notices are present; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c6924a108325901b1a77d9199ed0)