### PR TITLE
Support rectangular DATA.IMG_SIZE (non-1:1)

### DIFF
--- a/config.py
+++ b/config.py
@@ -375,6 +375,17 @@ def update_config(config, args):
     if args.opts:
         config.merge_from_list(args.opts)
 
+    def _normalize_img_size(img_size):
+        if isinstance(img_size, int):
+            return (img_size, img_size)
+        if isinstance(img_size, (list, tuple)) and len(img_size) == 2:
+            return (int(img_size[0]), int(img_size[1]))
+        raise ValueError(
+            f"DATA.IMG_SIZE must be an int or [height, width], got: {img_size}"
+        )
+
+    config.DATA.IMG_SIZE = _normalize_img_size(config.DATA.IMG_SIZE)
+
     def _check_args(name):
         if hasattr(args, name) and eval(f'args.{name}'):
             return True

--- a/data/build.py
+++ b/data/build.py
@@ -128,11 +128,12 @@ def build_dataset(is_train, config):
 
 
 def build_transform(is_train, config):
-    resize_im = config.DATA.IMG_SIZE > 32
+    img_size = tuple(config.DATA.IMG_SIZE)
+    resize_im = min(img_size) > 32
     if is_train:
         # this should always dispatch to transforms_imagenet_train
         transform = create_transform(
-            input_size=config.DATA.IMG_SIZE,
+            input_size=img_size,
             is_training=True,
             color_jitter=config.AUG.COLOR_JITTER if config.AUG.COLOR_JITTER > 0 else None,
             auto_augment=config.AUG.AUTO_AUGMENT if config.AUG.AUTO_AUGMENT != 'none' else None,
@@ -145,22 +146,22 @@ def build_transform(is_train, config):
             # replace RandomResizedCropAndInterpolation with
             # RandomCrop
             transform.transforms[0] = transforms.RandomCrop(
-                config.DATA.IMG_SIZE, padding=4)
+                img_size, padding=4)
         return transform
 
     t = []
     if resize_im:
         if config.TEST.CROP:
-            size = int((256 / 224) * config.DATA.IMG_SIZE)
+            size = tuple(int((256 / 224) * dim) for dim in img_size)
             t.append(
                 transforms.Resize(size, interpolation=_pil_interp(
                     config.DATA.INTERPOLATION)),
                 # to maintain same ratio w.r.t. 224 images
             )
-            t.append(transforms.CenterCrop(config.DATA.IMG_SIZE))
+            t.append(transforms.CenterCrop(img_size))
         else:
             t.append(
-                transforms.Resize((config.DATA.IMG_SIZE, config.DATA.IMG_SIZE),
+                transforms.Resize(img_size,
                                   interpolation=_pil_interp(config.DATA.INTERPOLATION))
             )
 

--- a/data/data_simmim_ft.py
+++ b/data/data_simmim_ft.py
@@ -73,11 +73,12 @@ def build_dataset(is_train, config):
 
 
 def build_transform(is_train, config):
-    resize_im = config.DATA.IMG_SIZE > 32
+    img_size = tuple(config.DATA.IMG_SIZE)
+    resize_im = min(img_size) > 32
     if is_train:
         # this should always dispatch to transforms_imagenet_train
         transform = create_transform(
-            input_size=config.DATA.IMG_SIZE,
+            input_size=img_size,
             is_training=True,
             color_jitter=config.AUG.COLOR_JITTER if config.AUG.COLOR_JITTER > 0 else None,
             auto_augment=config.AUG.AUTO_AUGMENT if config.AUG.AUTO_AUGMENT != 'none' else None,
@@ -89,21 +90,21 @@ def build_transform(is_train, config):
         if not resize_im:
             # replace RandomResizedCropAndInterpolation with
             # RandomCrop
-            transform.transforms[0] = transforms.RandomCrop(config.DATA.IMG_SIZE, padding=4)
+            transform.transforms[0] = transforms.RandomCrop(img_size, padding=4)
         return transform
 
     t = []
     if resize_im:
         if config.TEST.CROP:
-            size = int((256 / 224) * config.DATA.IMG_SIZE)
+            size = tuple(int((256 / 224) * dim) for dim in img_size)
             t.append(
                 transforms.Resize(size, interpolation=_pil_interp(config.DATA.INTERPOLATION)),
                 # to maintain same ratio w.r.t. 224 images
             )
-            t.append(transforms.CenterCrop(config.DATA.IMG_SIZE))
+            t.append(transforms.CenterCrop(img_size))
         else:
             t.append(
-                transforms.Resize((config.DATA.IMG_SIZE, config.DATA.IMG_SIZE),
+                transforms.Resize(img_size,
                                   interpolation=_pil_interp(config.DATA.INTERPOLATION))
             )
 

--- a/data/data_simmim_pt.py
+++ b/data/data_simmim_pt.py
@@ -47,9 +47,10 @@ class MaskGenerator:
 
 class SimMIMTransform:
     def __init__(self, config):
+        img_size = tuple(config.DATA.IMG_SIZE)
         self.transform_img = T.Compose([
             T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
-            T.RandomResizedCrop(config.DATA.IMG_SIZE, scale=(0.67, 1.), ratio=(3. / 4., 4. / 3.)),
+            T.RandomResizedCrop(img_size, scale=(0.67, 1.), ratio=(3. / 4., 4. / 3.)),
             T.RandomHorizontalFlip(),
             T.ToTensor(),
             T.Normalize(mean=torch.tensor(IMAGENET_DEFAULT_MEAN),std=torch.tensor(IMAGENET_DEFAULT_STD)),
@@ -60,8 +61,11 @@ class SimMIMTransform:
         else:
             raise NotImplementedError
         
+        if img_size[0] != img_size[1]:
+            raise ValueError("SimMIM pretraining currently requires square DATA.IMG_SIZE")
+
         self.mask_generator = MaskGenerator(
-            input_size=config.DATA.IMG_SIZE,
+            input_size=img_size[0],
             mask_patch_size=config.DATA.MASK_PATCH_SIZE,
             model_patch_size=model_patch_size,
             mask_ratio=config.DATA.MASK_RATIO,

--- a/data/mtl_ds.py
+++ b/data/mtl_ds.py
@@ -809,11 +809,18 @@ def get_tasks_config(db_name, task_list, img_size):
         task_cfg.ALL_TASKS.FLAGVALS[k] = task_cfg.FLAGVALS[k]
         task_cfg.ALL_TASKS.INFER_FLAGVALS[k] = task_cfg.INFER_FLAGVALS[k]
 
+    if isinstance(img_size, int):
+        img_scale = (img_size, img_size)
+    elif isinstance(img_size, (list, tuple)) and len(img_size) == 2:
+        img_scale = (int(img_size[0]), int(img_size[1]))
+    else:
+        raise ValueError(f"img_size must be an int or [height, width], got {img_size}")
+
     task_cfg.TRAIN = {
-        'SCALE': (img_size, img_size),
+        'SCALE': img_scale,
     }
     task_cfg.TEST = {
-        'SCALE': (img_size, img_size),
+        'SCALE': img_scale,
     }
 
     return task_cfg, other_args

--- a/main.py
+++ b/main.py
@@ -162,7 +162,8 @@ def main(config):
     logger.info(f"number of params: {n_parameters / 1e6} M")
 
     model.cuda()
-    macs, params = get_model_complexity_info(model, (3, config.DATA.IMG_SIZE, config.DATA.IMG_SIZE), as_strings=True,
+    img_h, img_w = config.DATA.IMG_SIZE
+    macs, params = get_model_complexity_info(model, (3, img_h, img_w), as_strings=True,
                                              print_per_layer_stat=False, verbose=False)
 
     logger.info(f"ptflops GMACS = {macs} and params = {params}")


### PR DESCRIPTION
### Motivation
- Allow `DATA.IMG_SIZE` to accept non-square inputs so users can specify `(height, width)` instead of being forced to use 1:1 sizes.
- Propagate rectangular size handling through transforms, multi-task scale settings and FLOPs/macs computation so behavior is consistent across the codebase.

### Description
- Normalize `DATA.IMG_SIZE` in `update_config` so it accepts either a single integer (expanded to `(size, size)`) or a two-element list/tuple `(H, W)`, and store it as a `(height, width)` tuple (`config.py`).
- Update ImageNet transform builders in `data/build.py` and fine-tune transforms in `data/data_simmim_ft.py` to accept tuple `input_size` and handle resize/crop logic using `img_size` instead of a scalar `DATA.IMG_SIZE`.
- Update SimMIM pretraining transforms in `data/data_simmim_pt.py` to accept tuple `DATA.IMG_SIZE` for image transforms but add an explicit error when a non-square size is provided because mask generation currently requires square inputs.
- Update multi-task task config generation in `data/mtl_ds.py` so `TRAIN.SCALE` and `TEST.SCALE` preserve `(H, W)` when `img_size` is a tuple.
- Use `(img_h, img_w)` when building the FLOPs input shape in `main.py` (i.e. `get_model_complexity_info(model, (3, img_h, img_w))`).

### Testing
- Ran Python byte-compile on modified modules with `python -m compileall config.py data/build.py data/data_simmim_ft.py data/data_simmim_pt.py data/mtl_ds.py main.py`, which succeeded.
- Attempted runtime config validation by calling `get_config(...)`, but this was blocked by the environment missing `libGL.so.1` required by `cv2`, resulting in an import error; no further runtime tests could be executed in this environment.
- No new unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a58a083cc8325b11bf78a2f2a2d3d)