### PR TITLE
Fix DATA.IMG_SIZE type mismatch when loading YAML configs

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,7 +37,7 @@ _C.DATA.DATA_PATH = ''
 # Dataset name
 _C.DATA.DATASET = 'nyud'
 # Input image size
-_C.DATA.IMG_SIZE = 224
+_C.DATA.IMG_SIZE = [224, 224]
 # _C.DATA.IMG_SIZE = (480, 640)
 # _C.DATA.IMG_SIZE = (448, 448)
 # Interpolation to resize image (random, bilinear, bicubic)
@@ -353,13 +353,18 @@ def _update_config_from_file(config, cfg_file):
     with open(cfg_file, 'r') as f:
         yaml_cfg = yaml.load(f, Loader=yaml.FullLoader)
 
+    if 'DATA' in yaml_cfg and 'IMG_SIZE' in yaml_cfg['DATA']:
+        img_size = yaml_cfg['DATA']['IMG_SIZE']
+        if isinstance(img_size, int):
+            yaml_cfg['DATA']['IMG_SIZE'] = [img_size, img_size]
+
     for cfg in yaml_cfg.setdefault('BASE', ['']):
         if cfg:
             _update_config_from_file(
                 config, os.path.join(os.path.dirname(cfg_file), cfg)
             )
     print('=> merge config from {}'.format(cfg_file))
-    config.merge_from_file(cfg_file)
+    config.merge_from_other_cfg(CN(yaml_cfg))
     config.freeze()
 
 


### PR DESCRIPTION
### Motivation
- Loading YAML configs that specify `DATA.IMG_SIZE` as a list (e.g. `[448, 576]`) raised a YACS type mismatch because the default was an `int` (`224`).
- The change ensures rectangular image-size configs are supported and avoids merge-time type errors.

### Description
- Changed default `DATA.IMG_SIZE` from `224` to a 2-element list `[224, 224]` in `config.py` to make list shape the canonical form.
- Added preprocessing in `_update_config_from_file` to normalize scalar YAML `DATA.IMG_SIZE` values into `[size, size]` before merging.
- Replaced `config.merge_from_file(cfg_file)` with `config.merge_from_other_cfg(CN(yaml_cfg))` so the normalized YAML object is merged with YACS after preprocessing.

### Testing
- Ran `python -m py_compile config.py` which succeeded, confirming the file is syntactically valid. 
- Attempted a small runtime config-load reproduction (`get_config`) but it failed due to a missing system dependency (`libGL.so.1`) required by `cv2` during import, which is unrelated to the config logic and prevented full runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa04846b08325b3fcf2467d18e154)