### PR TITLE
Add dynamic online stage-splitting router for MTLoRA (OURS)

### DIFF
--- a/config.py
+++ b/config.py
@@ -346,6 +346,16 @@ _C.MODEL.MTLORA.PROJ_ENABLED = True
 _C.MODEL.MTLORA.FC1_ENABLED = True
 _C.MODEL.MTLORA.FC2_ENABLED = True
 _C.MODEL.MTLORA.DOWNSAMPLER_ENABLED = False
+_C.MODEL.MTLORA.USE_OURS = False
+_C.MODEL.MTLORA.OURS_MAX_GROUPS = [1, 1, 4, 4]
+_C.MODEL.MTLORA.OURS_DELTA_THRESHOLD = 0.05
+_C.MODEL.MTLORA.OURS_WARMUP_RATIO = 0.1
+_C.MODEL.MTLORA.OURS_INTERVAL_EPOCHS = 10
+_C.MODEL.MTLORA.OURS_COOLDOWN_EPOCHS = 10
+_C.MODEL.MTLORA.OURS_STOP_SPLIT_RATIO = 0.5
+_C.MODEL.MTLORA.OURS_PROBE_RATIO = 0.04
+_C.MODEL.MTLORA.OURS_SYM_BREAK_BATCHES = 2
+_C.MODEL.MTLORA.OURS_SPLIT_LR_SCALE = 0.5
 
 
 def _update_config_from_file(config, cfg_file):
@@ -510,6 +520,13 @@ def update_config(config, args):
 
     # Normalize MTLoRA config
     if config.MODEL.MTLORA.ENABLED:
+        if not isinstance(config.MODEL.MTLORA.OURS_MAX_GROUPS, list):
+            config.MODEL.MTLORA.OURS_MAX_GROUPS = [
+                config.MODEL.MTLORA.OURS_MAX_GROUPS] * len(config.MODEL.SWIN.DEPTHS)
+        elif len(config.MODEL.MTLORA.OURS_MAX_GROUPS) == 1:
+            config.MODEL.MTLORA.OURS_MAX_GROUPS = config.MODEL.MTLORA.OURS_MAX_GROUPS * len(config.MODEL.SWIN.DEPTHS)
+        else:
+            assert len(config.MODEL.MTLORA.OURS_MAX_GROUPS) == len(config.MODEL.SWIN.DEPTHS)
         if not isinstance(config.MODEL.MTLORA.R, list):
             config.MODEL.MTLORA.R = [
                 config.MODEL.MTLORA.R] * len(config.MODEL.SWIN.DEPTHS)

--- a/configs/mtlora/tiny_448/pascal/mtlora_tiny_448_r64_scale4_pertask_ours.yaml
+++ b/configs/mtlora/tiny_448/pascal/mtlora_tiny_448_r64_scale4_pertask_ours.yaml
@@ -1,0 +1,52 @@
+DATA:
+  IMG_SIZE: 448
+MODEL:
+  TYPE: swin
+  NAME: mtlora_tiny_448_r64_scale4_pertask_ours
+  DROP_PATH_RATE: 0.2
+  SWIN:
+    EMBED_DIM: 96
+    DEPTHS: [2, 2, 6, 2]
+    NUM_HEADS: [3, 6, 12, 24]
+    WINDOW_SIZE: 7
+  MTLORA:
+    ENABLED: True
+    USE_OURS: True
+    R: [64, 64, 64, 64]
+    SHARED_SCALE: [4.0]
+    TASK_SCALE: [4.0]
+    DROPOUT: [0.05, 0.05, 0.05, 0.05]
+    TRAINABLE_SCALE_SHARED: False
+    TRAINABLE_SCALE_PER_TASK: False
+    INTERMEDIATE_SPECIALIZATION: False
+    FREEZE_PRETRAINED: True
+    SPLIT_QKV: False
+    QKV_ENABLED: True
+    PROJ_ENABLED: True
+    FC1_ENABLED: True
+    FC2_ENABLED: True
+    DOWNSAMPLER_ENABLED: False
+    OURS_MAX_GROUPS: [1, 1, 4, 4]
+    OURS_DELTA_THRESHOLD: 0.05
+    OURS_WARMUP_RATIO: 0.1
+    OURS_INTERVAL_EPOCHS: 10
+    OURS_COOLDOWN_EPOCHS: 10
+    OURS_STOP_SPLIT_RATIO: 0.5
+    OURS_PROBE_RATIO: 0.04
+    OURS_SYM_BREAK_BATCHES: 2
+    OURS_SPLIT_LR_SCALE: 0.5
+    R_PER_TASK:
+      semseg: [4]
+      normals: [4]
+      sal: [4]
+      human_parts: [4]
+      edge: [4]
+      depth: [4]
+      shared: [64]
+  DECODER_HEAD:
+    semseg: hrnet
+    normals: hrnet
+    sal: hrnet
+    human_parts: hrnet
+    edge: hrnet
+    depth: hrnet

--- a/main.py
+++ b/main.py
@@ -319,6 +319,7 @@ def main(config):
         epoch_cr_records, epoch_cr_sum, epoch_cr_count = train_one_epoch(config, model, criterion, data_loader_train,
                                                                          optimizer, epoch, mixup_fn, lr_scheduler,
                                                                          loss_scaler, teacher=teacher)
+        _maybe_run_online_split(config, model, criterion, data_loader_train, optimizer, epoch, logger)
         if config.TRAIN.ENABLE_CONFLICT_RATIO:
             total_cr_sum += epoch_cr_sum
             total_cr_count += epoch_cr_count
@@ -460,6 +461,82 @@ def _compute_conflict_ratio(loss_dict, shared_params, task_order, task_weights):
         return 0.0
 
     return float(sum(ratios) / len(ratios))
+
+
+def _get_stage_lora_params(model, stage_idx):
+    params = []
+    for name, p in model.named_parameters():
+        if p.requires_grad and f"backbone.layers.{stage_idx}." in name and "lora" in name:
+            params.append(p)
+    return params
+
+
+def _collect_task_stage_grads(config, model, criterion, data_loader, stage_idx, n_probe):
+    stage_params = _get_stage_lora_params(model, stage_idx)
+    if not stage_params:
+        return {}
+    task_grads = {t: [] for t in config.TASKS}
+    was_training = model.training
+    model.eval()
+    it = iter(data_loader)
+    for _ in range(n_probe):
+        try:
+            batch = next(it)
+        except StopIteration:
+            break
+        samples = batch['image'].cuda(non_blocking=True)
+        targets = {task: batch[task].cuda(non_blocking=True) for task in config.TASKS}
+        with torch.cuda.amp.autocast(enabled=config.AMP_ENABLE):
+            outputs = model(samples)
+            _, loss_dict = criterion(outputs, targets)
+        for t in config.TASKS:
+            grads = torch.autograd.grad(loss_dict[t], stage_params, retain_graph=True, allow_unused=True)
+            vec = torch.cat([(g.detach().float().reshape(-1) if g is not None else torch.zeros_like(p).float().reshape(-1))
+                            for g, p in zip(grads, stage_params)])
+            task_grads[t].append(vec)
+    if was_training:
+        model.train()
+    return {t: torch.stack(v, 0).mean(0) for t, v in task_grads.items() if v}
+
+
+def _maybe_run_online_split(config, model, criterion, data_loader, optimizer, epoch, logger):
+    if not (config.MODEL.MTLORA.ENABLED and config.MODEL.MTLORA.USE_OURS):
+        return
+    wrapped = model.module if hasattr(model, 'module') else model
+    backbone = wrapped.backbone if hasattr(wrapped, 'backbone') else None
+    router = getattr(backbone, 'dynamic_router', None)
+    if router is None:
+        return
+    warmup_epochs = max(1, int(config.TRAIN.EPOCHS * config.MODEL.MTLORA.OURS_WARMUP_RATIO))
+    stop_epoch = int(config.TRAIN.EPOCHS * config.MODEL.MTLORA.OURS_STOP_SPLIT_RATIO)
+    interval = max(1, int(config.MODEL.MTLORA.OURS_INTERVAL_EPOCHS))
+    cooldown = max(0, int(config.MODEL.MTLORA.OURS_COOLDOWN_EPOCHS))
+    last_split = getattr(backbone, '_last_split_epoch', -10**9)
+    if epoch < warmup_epochs or epoch >= stop_epoch or ((epoch - warmup_epochs) % interval != 0) or (epoch - last_split < cooldown):
+        return
+    probe_batches = max(1, int(len(data_loader) * config.MODEL.MTLORA.OURS_PROBE_RATIO))
+    for stage_idx in range(backbone.num_layers):
+        if not router.can_split_stage(stage_idx):
+            continue
+        grads = _collect_task_stage_grads(config, model, criterion, data_loader, stage_idx, probe_batches)
+        if len(grads) < 2:
+            continue
+        sim = {(t1, t2): torch.nn.functional.cosine_similarity(grads[t1], grads[t2], dim=0).item()
+               for t1 in grads for t2 in grads}
+        for group in list(router.stage_groups[stage_idx]):
+            best = router.best_bisect(group, sim)
+            if best is None:
+                continue
+            delta, ga, gb = best
+            if delta <= float(config.MODEL.MTLORA.OURS_DELTA_THRESHOLD):
+                continue
+            parent_idx, new_idx = router.apply_split(stage_idx, group, ga, gb)
+            for m in backbone.modules():
+                if hasattr(m, 'layer_idx') and m.layer_idx == stage_idx and hasattr(m, 'clone_group'):
+                    m.clone_group(parent_idx, new_idx)
+            backbone._last_split_epoch = epoch
+            logger.info(f"[Ours] Split stage={stage_idx}, delta={delta:.4f}, {group} -> {ga}|{gb}")
+            return
 
 
 def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mixup_fn, lr_scheduler, loss_scaler, task=None, teacher=None):

--- a/models/dynamic_split.py
+++ b/models/dynamic_split.py
@@ -1,0 +1,56 @@
+import itertools
+
+
+class DynamicSplitRouter:
+    def __init__(self, tasks, num_stages, max_groups, enabled=False):
+        self.tasks = list(tasks)
+        self.num_stages = num_stages
+        self.max_groups = list(max_groups)
+        self.enabled = enabled
+        self.stage_groups = {s: [list(self.tasks)] for s in range(num_stages)}
+
+    def task_to_group(self, stage_idx):
+        mapping = {}
+        for gid, group in enumerate(self.stage_groups[stage_idx]):
+            for task in group:
+                mapping[task] = gid
+        return mapping
+
+    def can_split_stage(self, stage_idx):
+        return self.enabled and stage_idx >= 2 and len(self.stage_groups[stage_idx]) < self.max_groups[stage_idx]
+
+    @staticmethod
+    def _group_score(group, sim):
+        if len(group) <= 1:
+            return 0.0
+        total = 0.0
+        for t in group:
+            total += sum(sim.get((t, tt), 0.0) for tt in group if tt != t) / (len(group) - 1)
+        return total
+
+    def best_bisect(self, group, sim):
+        if len(group) < 2:
+            return None
+        no_split = self._group_score(group, sim)
+        best = None
+        n = len(group)
+        for r in range(1, n):
+            for combo in itertools.combinations(group, r):
+                if group[0] not in combo:
+                    continue
+                a = list(combo)
+                b = [x for x in group if x not in combo]
+                if not b:
+                    continue
+                score = self._group_score(a, sim) + self._group_score(b, sim)
+                delta = score - no_split
+                if best is None or delta > best[0]:
+                    best = (delta, a, b)
+        return best
+
+    def apply_split(self, stage_idx, parent_group, a, b):
+        groups = self.stage_groups[stage_idx]
+        parent_idx = groups.index(parent_group)
+        groups[parent_idx:parent_idx + 1] = [a, b]
+        self.stage_groups[stage_idx] = groups
+        return parent_idx, parent_idx + 1

--- a/models/lora.py
+++ b/models/lora.py
@@ -58,6 +58,13 @@ import torch.nn as nn
 from torch.nn import functional as F
 from typing_extensions import Self
 
+GLOBAL_DYNAMIC_ROUTER = None
+
+
+def set_global_dynamic_router(router):
+    global GLOBAL_DYNAMIC_ROUTER
+    GLOBAL_DYNAMIC_ROUTER = router
+
 
 class LoRALayer(nn.Module):
     def __init__(self, r: int, lora_alpha: int, lora_dropout: float):
@@ -172,6 +179,9 @@ class MTLoRALinear(LoRALayer):
         trainable_scale_shared=False,
         trainable_scale_per_task=False,
         shared_mode: str = 'matrix',
+        dynamic_router=None,
+        layer_idx: int = -1,
+        max_dynamic_groups: int = 4,
         **kwargs,
     ):
         assert shared_mode in ['matrix', 'matrixv2',
@@ -195,6 +205,10 @@ class MTLoRALinear(LoRALayer):
             in_features, out_features, **kwargs)
 
         self.tasks = tasks
+        self.dynamic_router = dynamic_router if dynamic_router is not None else GLOBAL_DYNAMIC_ROUTER
+        self.layer_idx = layer_idx
+        self.max_dynamic_groups = max_dynamic_groups
+        self.dynamic_enabled = dynamic_router is not None and layer_idx >= 0 and layer_idx >= 2 and self.r_shared > 0
         self.shared_mode = shared_mode
         self.r_shared = int(r.get('shared', 0))
         self.r_tasks = {task: int(r.get(task, 0)) for task in (tasks or [])}
@@ -230,10 +244,20 @@ class MTLoRALinear(LoRALayer):
                 assert has_tasks
                 self.lora_norm = nn.LayerNorm(out_features)
             elif self.shared_mode == 'matrix' or self.shared_mode == 'matrixv2':
-                self.lora_shared_A = nn.Parameter(
-                    self.linear.weight.new_zeros((self.r_shared, in_features)))
-                self.lora_shared_B = nn.Parameter(
-                    self.linear.weight.new_zeros((out_features, self.r_shared)))
+                if self.dynamic_enabled:
+                    self.lora_group_A = nn.ParameterDict({
+                        f"g{i}": nn.Parameter(self.linear.weight.new_zeros((self.r_shared, in_features)))
+                        for i in range(max_dynamic_groups)
+                    })
+                    self.lora_group_B = nn.ParameterDict({
+                        f"g{i}": nn.Parameter(self.linear.weight.new_zeros((out_features, self.r_shared)))
+                        for i in range(max_dynamic_groups)
+                    })
+                else:
+                    self.lora_shared_A = nn.Parameter(
+                        self.linear.weight.new_zeros((self.r_shared, in_features)))
+                    self.lora_shared_B = nn.Parameter(
+                        self.linear.weight.new_zeros((out_features, self.r_shared)))
             else:
                 raise NotImplementedError
             if trainable_scale_shared:
@@ -257,6 +281,23 @@ class MTLoRALinear(LoRALayer):
                 nn.init.kaiming_uniform_(
                     self.lora_tasks_A[task], a=math.sqrt(5))
                 nn.init.zeros_(self.lora_tasks_B[task])
+        if hasattr(self, "lora_group_A"):
+            for key in self.lora_group_A.keys():
+                nn.init.kaiming_uniform_(self.lora_group_A[key], a=math.sqrt(5))
+                nn.init.zeros_(self.lora_group_B[key])
+
+    def clone_group(self, src_idx: int, dst_idx: int):
+        if not hasattr(self, "lora_group_A"):
+            return
+        src, dst = f"g{src_idx}", f"g{dst_idx}"
+        self.lora_group_A[dst].data.copy_(self.lora_group_A[src].data)
+        self.lora_group_B[dst].data.copy_(self.lora_group_B[src].data)
+
+    def branch_parameters(self, group_idx: int):
+        if not hasattr(self, "lora_group_A"):
+            return []
+        key = f"g{group_idx}"
+        return [self.lora_group_A[key], self.lora_group_B[key]]
 
     def merge(self):
         """Merges the LoRA weights into the full-rank weights (W = W + delta_W)."""
@@ -281,8 +322,20 @@ class MTLoRALinear(LoRALayer):
 
         if self.has_shared_lora:
             if self.shared_mode == 'matrix':
-                lora = (x @ self.lora_shared_A.transpose(0, 1)
-                        @ self.lora_shared_B.transpose(0, 1)) * self.lora_shared_scale
+                if self.dynamic_enabled and hasattr(self, "lora_group_A"):
+                    task_to_group = self.dynamic_router.task_to_group(self.layer_idx)
+                    lora_tasks = {}
+                    for task, gid in task_to_group.items():
+                        x_in = x if x_tasks is None else x_tasks.get(task, x)
+                        key = f"g{gid}"
+                        delta = (x_in @ self.lora_group_A[key].transpose(0, 1)
+                                 @ self.lora_group_B[key].transpose(0, 1)) * self.lora_shared_scale
+                        lora_tasks[task] = pretrained + delta
+                    lora = (x @ self.lora_group_A['g0'].transpose(0, 1)
+                            @ self.lora_group_B['g0'].transpose(0, 1)) * self.lora_shared_scale
+                else:
+                    lora = (x @ self.lora_shared_A.transpose(0, 1)
+                            @ self.lora_shared_B.transpose(0, 1)) * self.lora_shared_scale
             elif self.shared_mode == 'matrixv2':
                 lora = (x @ self.lora_shared_A.transpose(0, 1)
                         @ self.lora_shared_B.transpose(0, 1)) * self.lora_shared_scale

--- a/models/swin_transformer_mtlora.py
+++ b/models/swin_transformer_mtlora.py
@@ -17,7 +17,8 @@ import torch
 from torch import Tensor
 import torch.nn as nn
 from timm.models.layers import DropPath, to_2tuple, trunc_normal_
-from models.lora import MTLoRALinear, MTLoRAQKV
+from models.lora import MTLoRALinear, MTLoRAQKV, set_global_dynamic_router
+from models.dynamic_split import DynamicSplitRouter
 
 try:
     import os
@@ -70,6 +71,9 @@ class Mlp(nn.Module):
                 trainable_scale_shared=mtlora.TRAINABLE_SCALE_SHARED,
                 trainable_scale_per_task=mtlora.TRAINABLE_SCALE_PER_TASK,
                 shared_mode=mtlora.SHARED_MODE,
+                dynamic_router=getattr(mtlora, 'DYNAMIC_ROUTER', None),
+                layer_idx=layer_idx,
+                max_dynamic_groups=max(getattr(mtlora, 'OURS_MAX_GROUPS', [4])),
             )
         else:
             self.fc1 = CompatLinear(in_features, hidden_features)
@@ -86,6 +90,9 @@ class Mlp(nn.Module):
                 trainable_scale_shared=mtlora.TRAINABLE_SCALE_SHARED,
                 trainable_scale_per_task=mtlora.TRAINABLE_SCALE_PER_TASK,
                 shared_mode=mtlora.SHARED_MODE,
+                dynamic_router=getattr(mtlora, 'DYNAMIC_ROUTER', None),
+                layer_idx=layer_idx,
+                max_dynamic_groups=max(getattr(mtlora, 'OURS_MAX_GROUPS', [4])),
             )
         else:
             self.fc2 = CompatLinear(hidden_features, out_features)
@@ -202,6 +209,9 @@ class WindowAttention(nn.Module):
                     trainable_scale_shared=mtlora.TRAINABLE_SCALE_SHARED,
                     trainable_scale_per_task=mtlora.TRAINABLE_SCALE_PER_TASK,
                     shared_mode=mtlora.SHARED_MODE,
+                    dynamic_router=getattr(mtlora, 'DYNAMIC_ROUTER', None),
+                    layer_idx=layer_idx,
+                    max_dynamic_groups=max(getattr(mtlora, 'OURS_MAX_GROUPS', [4])),
                 )
             else:
                 linear_cls = MTLoRALinear
@@ -217,6 +227,9 @@ class WindowAttention(nn.Module):
                     trainable_scale_shared=mtlora.TRAINABLE_SCALE_SHARED,
                     trainable_scale_per_task=mtlora.TRAINABLE_SCALE_PER_TASK,
                     shared_mode=mtlora.SHARED_MODE,
+                    dynamic_router=getattr(mtlora, 'DYNAMIC_ROUTER', None),
+                    layer_idx=layer_idx,
+                    max_dynamic_groups=max(getattr(mtlora, 'OURS_MAX_GROUPS', [4])),
                     )
         else:
             self.qkv = CompatLinear(dim, dim * 3, bias=qkv_bias)
@@ -236,6 +249,9 @@ class WindowAttention(nn.Module):
                 trainable_scale_shared=mtlora.TRAINABLE_SCALE_SHARED,
                 trainable_scale_per_task=mtlora.TRAINABLE_SCALE_PER_TASK,
                 shared_mode=mtlora.SHARED_MODE,
+                dynamic_router=getattr(mtlora, 'DYNAMIC_ROUTER', None),
+                layer_idx=layer_idx,
+                max_dynamic_groups=max(getattr(mtlora, 'OURS_MAX_GROUPS', [4])),
             )
         else:
             self.proj = CompatLinear(dim, dim)
@@ -516,6 +532,9 @@ class PatchMerging(nn.Module):
                 trainable_scale_shared=mtlora.TRAINABLE_SCALE_SHARED,
                 trainable_scale_per_task=mtlora.TRAINABLE_SCALE_PER_TASK,
                 shared_mode=mtlora.SHARED_MODE,
+                dynamic_router=getattr(mtlora, 'DYNAMIC_ROUTER', None),
+                layer_idx=layer_idx,
+                max_dynamic_groups=max(getattr(mtlora, 'OURS_MAX_GROUPS', [4])),
                 )
         else:
             self.reduction = CompatLinear(4 * dim, 2 * dim, bias=False)
@@ -731,6 +750,13 @@ class SwinTransformerMTLoRA(nn.Module):
         self.mlp_ratio = mlp_ratio
         self.tasks = tasks
         self.mtlora = mtlora
+        self.dynamic_router = DynamicSplitRouter(
+            tasks=tasks,
+            num_stages=self.num_layers,
+            max_groups=getattr(mtlora, 'OURS_MAX_GROUPS', [1, 1, 4, 4]),
+            enabled=getattr(mtlora, 'USE_OURS', False),
+        )
+        set_global_dynamic_router(self.dynamic_router)
 
         # Print lora params:
         if mtlora is not None:


### PR DESCRIPTION
### Motivation
- Introduce an online dynamic splitting mechanism for MTLoRA to let layers specialize by splitting shared LoRA groups per stage when task gradient dissimilarity warrants it. 
- Expose tunable hyperparameters for the splitting algorithm in the config to support controlled warmup, probing, intervals, and cooldown behavior. 
- Integrate splitting into the training loop so splits can be applied during training without requiring a separate offline preprocessing step. 

### Description
- Add new config entries under `MODEL.MTLORA` (`USE_OURS`, `OURS_MAX_GROUPS`, `OURS_DELTA_THRESHOLD`, `OURS_WARMUP_RATIO`, `OURS_INTERVAL_EPOCHS`, `OURS_COOLDOWN_EPOCHS`, `OURS_STOP_SPLIT_RATIO`, `OURS_PROBE_RATIO`, `OURS_SYM_BREAK_BATCHES`, `OURS_SPLIT_LR_SCALE`) and normalize `OURS_MAX_GROUPS` in `update_config`. 
- Add a new YAML example config `configs/mtlora/tiny_448/pascal/mtlora_tiny_448_r64_scale4_pertask_ours.yaml` demonstrating the `USE_OURS` setup and per-task `R_PER_TASK`. 
- Implement `DynamicSplitRouter` in `models/dynamic_split.py` which maintains per-stage task groups, computes bisection scores using task-task similarity, and applies group splits. 
- Extend the LoRA implementation in `models/lora.py` with a global router hook (`set_global_dynamic_router`), per-layer `dynamic_router` support, grouped shared-weights storage (`lora_group_A/B`), `clone_group`, and routing-aware forward logic to produce per-task branch outputs when dynamic routing is enabled. 
- Update `models/swin_transformer_mtlora.py` to instantiate the `DynamicSplitRouter`, call `set_global_dynamic_router`, and pass router, `layer_idx`, and `max_dynamic_groups` into `MTLoRALinear`/`MTLoRAQKV`/downsampler instances. 
- Add online split orchestration to `main.py` including helpers `_get_stage_lora_params`, `_collect_task_stage_grads`, and `_maybe_run_online_split` that probe task gradients, compute cosine similarities, select and apply a split via the router, clone LoRA group parameters across layers, and log split events; the hook is invoked after each epoch via `_maybe_run_online_split`. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a505027ba48325be075065b54e6571)