### PR TITLE
Replace NYUD edge labels with segmentation-derived data and restart training

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ Offline edge evaluation uses the same pure Python metric implementation as onlin
 python scripts/eval_edge_predictions.py --dataset nyud --pred-dir /path/to/predictions --gt-root /path/to/NYUD_MT
 ```
 
+If you already have a prepared `NYUD_MT` root and only need to replace placeholder edge labels with segmentation-derived ones:
+
+```bash
+python scripts/derive_nyud_edge_from_semseg.py --dataset-root /path/to/NYUD_MT --replace-edge --overwrite
+```
+
 Note: derived semantic-boundary edges are useful for training and internal comparison, but they are not equivalent to an official independent NYUD edge benchmark.
 
 ## Authorship

--- a/README.md
+++ b/README.md
@@ -243,6 +243,40 @@ CUDA_VISIBLE_DEVICES=1 python -m torch.distributed.launch --nproc_per_node 1 --m
 
 ---
 
+## NYUD Edge Support
+
+NYUD edge is now supported as a first-class task for training, validation, and offline evaluation.
+
+- Training labels live under `edge/<image_id>.npy` as float32 binary edge maps.
+- Optional multi-annotator evaluation GT lives under `edge_eval/<image_id>.npz` with key `gts`.
+- If `edge_eval/` is missing, formal edge evaluation falls back to `edge/`.
+
+Prepare NYUDv2 with real edge GT when available:
+
+```bash
+python scripts/prepare_nyudv2.py --src /path/to/nyud_raw --dst /path/to/NYUD_MT --edge-source real --edge-root /path/to/nyud_edge_gt --edge-format auto --overwrite
+```
+
+Prepare NYUDv2 by deriving edges from semantic boundaries:
+
+```bash
+python scripts/prepare_nyudv2.py --src /path/to/nyud_raw --dst /path/to/NYUD_MT --edge-source derived --overwrite
+```
+
+Run NYUD four-task training or evaluation:
+
+```bash
+python -m torch.distributed.launch --nproc_per_node 1 main.py --cfg configs/mtlora/tiny_448/nyud/mtlora_tiny_448_r64_scale4_pertask_nyud.yaml --nyud /path/to/NYUD_MT --tasks semseg,normals,depth,edge --batch-size 8 --resume-backbone ./backbone/swin_tiny_patch4_window7_224.pth
+```
+
+Offline edge evaluation uses the same pure Python metric implementation as online validation:
+
+```bash
+python scripts/eval_edge_predictions.py --dataset nyud --pred-dir /path/to/predictions --gt-root /path/to/NYUD_MT
+```
+
+Note: derived semantic-boundary edges are useful for training and internal comparison, but they are not equivalent to an official independent NYUD edge benchmark.
+
 ## Authorship
 
 Since the release commit is squashed, the GitHub contributors tab doesn't reflect the authors' contributions. The following authors contributed equally to this codebase:

--- a/compute_delta_m.py
+++ b/compute_delta_m.py
@@ -1,22 +1,13 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
-"""
-Compute Δm (%) per validation from MTLoRA training logs and report the maximum.
-
-Δm 定义见 MTLoRA 论文 Eq. (3):
-Δm = (1/T) * Σ_i [ (-1)^{l_i} * (M_i - M_st,i) / M_st,i ] * 100%
-其中 l_i = 1 表示该任务是“越小越好”（如 Normals mean、Depth rmse）。
-"""
 
 import argparse
+import csv
 import json
 import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-# 论文 Table 1 的单任务基线（PASCAL MTL，Swin-T 单任务 fully fine-tuned）
-# 注意：你的本地单任务基线可能不同，建议用 --semseg-st 等参数覆盖！
+
 PAPER_ST_DEFAULTS = {
     "semseg_miou": 67.21,
     "human_miou": 61.93,
@@ -56,9 +47,14 @@ TASK_SPECS = {
         "arg": "depth_st",
         "display": "Depth rmse",
     },
+    "edge": {
+        "metric": "edge_odsf",
+        "higher_better": True,
+        "arg": "edge_st",
+        "display": "Edge odsF",
+    },
 }
 
-# 正则与状态解析
 RE_EPOCH = re.compile(r"EPOCH\s+(\d+)\s+training takes")
 RE_SEMSEG = re.compile(r"Semantic Segmentation mIoU:\s*([0-9.]+)")
 RE_HUMAN = re.compile(r"Human Parts mIoU:\s*([0-9.]+)")
@@ -68,236 +64,236 @@ RE_NORMALS_HEADER = re.compile(r"Results for Surface Normal Estimation")
 RE_NORMALS_MEAN = re.compile(r"\bmean:\s*([0-9.]+)")
 RE_DEPTH_HEADER = re.compile(r"Results for (Depth Estimation|depth prediction)", re.IGNORECASE)
 RE_DEPTH_RMSE = re.compile(r"\brmse\s*:?\s*([0-9.]+)", re.IGNORECASE)
+RE_EDGE_HEADER = re.compile(r"Edge Detection Evaluation")
+RE_EDGE_ODSF = re.compile(r"\bodsF:\s*([0-9.]+)", re.IGNORECASE)
 
 
 def parse_tasks(task_text: str) -> List[str]:
-    tasks = [t.strip() for t in task_text.split(",") if t.strip()]
+    tasks = [task.strip() for task in task_text.split(",") if task.strip()]
     if not tasks:
-        raise ValueError("--tasks 不能为空")
-    unknown = [t for t in tasks if t not in TASK_SPECS]
+        raise ValueError("--tasks cannot be empty")
+    unknown = [task for task in tasks if task not in TASK_SPECS]
     if unknown:
-        raise ValueError(f"未知任务: {unknown}，可选任务: {list(TASK_SPECS.keys())}")
+        raise ValueError(f"unknown tasks: {unknown}; choose from {list(TASK_SPECS.keys())}")
     deduped = []
-    for t in tasks:
-        if t not in deduped:
-            deduped.append(t)
+    for task in tasks:
+        if task not in deduped:
+            deduped.append(task)
     return deduped
 
+
 def parse_args():
-    ap = argparse.ArgumentParser(description="Compute Δm(%) from MTLoRA log.")
-    ap.add_argument("--log-file", required=True, type=Path, help="训练日志文件路径")
-    # 单任务基线的几种输入方式：
-    ap.add_argument("--st-json", type=Path, default=None,
-                    help="包含单任务基线的 JSON 文件，键可含 semseg_miou/human_miou/saliency_miou/normals_mean/depth_rmse")
-    ap.add_argument("--semseg-st", type=float, default=None, help="SemSeg 单任务 mIoU")
-    ap.add_argument("--human-st", type=float, default=None, help="Human Parts 单任务 mIoU")
-    ap.add_argument("--saliency-st", type=float, default=None, help="Saliency 单任务 mIoU")
-    ap.add_argument("--normals-st", type=float, default=None, help="Normals 单任务 mean（越低越好）")
-    ap.add_argument("--depth-st", type=float, default=None, help="Depth 单任务 rmse（越低越好）")
-    ap.add_argument("--tasks", type=str, default="semseg,human,saliency,normals,depth",
-                    help="参与计算 Δm 的任务，逗号分隔。可选: semseg,human,saliency,normals,depth")
-    ap.add_argument("--use-paper-st", action="store_true",
-                    help="若未显式提供基线，则使用论文 Table 1 的默认单任务基线（建议你用自家基线覆盖）")
-    ap.add_argument("--csv-out", type=Path, default=None, help="可选：将每次 eval 的指标与Δm保存成 CSV")
-    args = ap.parse_args()
+    parser = argparse.ArgumentParser(description="Compute Delta m(%) from MTLoRA logs.")
+    parser.add_argument("--log-file", required=True, type=Path, help="Training log path.")
+    parser.add_argument(
+        "--st-json",
+        type=Path,
+        default=None,
+        help="Optional JSON file containing single-task baselines.",
+    )
+    parser.add_argument("--semseg-st", type=float, default=None, help="SemSeg single-task mIoU.")
+    parser.add_argument("--human-st", type=float, default=None, help="Human Parts single-task mIoU.")
+    parser.add_argument("--saliency-st", type=float, default=None, help="Saliency single-task mIoU.")
+    parser.add_argument("--normals-st", type=float, default=None, help="Normals single-task mean.")
+    parser.add_argument("--depth-st", type=float, default=None, help="Depth single-task rmse.")
+    parser.add_argument("--edge-st", type=float, default=None, help="Edge single-task odsF.")
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default="semseg,human,saliency,normals,depth",
+        help="Comma-separated task list. Supported: semseg,human,saliency,normals,depth,edge",
+    )
+    parser.add_argument(
+        "--use-paper-st",
+        action="store_true",
+        help="Use paper defaults for any missing baselines when available.",
+    )
+    parser.add_argument(
+        "--csv-out",
+        type=Path,
+        default=None,
+        help="Optional CSV output for every parsed validation point.",
+    )
+    args = parser.parse_args()
     args.tasks = parse_tasks(args.tasks)
     return args
 
+
 def load_st_baseline(args) -> Dict[str, float]:
-    st = {}
+    baselines = {}
     if args.st_json is not None:
-        with args.st_json.open("r", encoding="utf-8") as f:
-            data = json.load(f)
+        with args.st_json.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
         if "normals_rmse" in data and "normals_mean" not in data:
             data["normals_mean"] = data["normals_rmse"]
-        st.update(data)
+        baselines.update(data)
 
-    # 覆盖式读取命令行参数
-    if args.semseg_st is not None:
-        st["semseg_miou"] = args.semseg_st
-    if args.human_st is not None:
-        st["human_miou"] = args.human_st
-    if args.saliency_st is not None:
-        st["saliency_miou"] = args.saliency_st
-    if args.normals_st is not None:
-        st["normals_mean"] = args.normals_st
-    if args.depth_st is not None:
-        st["depth_rmse"] = args.depth_st
+    for task_name, spec in TASK_SPECS.items():
+        arg_name = spec["arg"]
+        value = getattr(args, arg_name)
+        if value is not None:
+            baselines[spec["metric"]] = value
 
-    # 若仍缺失，用论文默认或报错
-    required_metrics = [TASK_SPECS[t]["metric"] for t in args.tasks]
-    missing = [k for k in required_metrics if k not in st]
-    if missing:
-        if args.use_paper_st:
-            for k in missing:
-                st[k] = PAPER_ST_DEFAULTS[k]
-            print("[WARN] 未提供完整单任务基线，使用论文默认：", {k: st[k] for k in missing})
-        else:
-            raise ValueError(
-                f"缺少单任务基线：{missing}。请通过 --st-json 或 --semseg-st/--human-st/--saliency-st/--normals-st/--depth-st "
-                f"提供，或加 --use-paper-st 使用论文默认基线（不推荐用于正式对比）。"
-            )
-    return st
+    required = [TASK_SPECS[task]["metric"] for task in args.tasks]
+    missing = [metric for metric in required if metric not in baselines]
+    if not missing:
+        return baselines
 
-def compute_delta_m(cur: Dict[str, float], st: Dict[str, float], tasks: List[str]) -> float:
+    if not args.use_paper_st:
+        raise ValueError(
+            "missing single-task baselines for "
+            f"{missing}; provide them through --st-json or explicit --*-st flags"
+        )
+
+    unavailable = [metric for metric in missing if metric not in PAPER_ST_DEFAULTS]
+    if unavailable:
+        raise ValueError(f"paper defaults do not include baselines for {unavailable}")
+
+    for metric in missing:
+        baselines[metric] = PAPER_ST_DEFAULTS[metric]
+    return baselines
+
+
+def compute_delta_m(current: Dict[str, float], baselines: Dict[str, float], tasks: List[str]) -> float:
     terms = []
     for task in tasks:
         spec = TASK_SPECS[task]
         metric = spec["metric"]
-        delta = (cur[metric] - st[metric]) / st[metric]
+        delta = (current[metric] - baselines[metric]) / baselines[metric]
         terms.append(delta if spec["higher_better"] else -delta)
     return 100.0 * sum(terms) / len(tasks)
 
-def parse_log(log_path: Path, tasks: List[str]) -> List[Dict]:
-    """返回按 eval 次序的记录：仅包含所选任务对应指标"""
-    records = []
-    cur_epoch: Optional[int] = None
 
-    # saliency/normals 的“上下文状态”标记
+def parse_log(log_path: Path, tasks: List[str]) -> List[Dict[str, float]]:
+    records = []
+    current_epoch: Optional[int] = None
     in_saliency = False
     in_normals = False
     in_depth = False
-
-    # 临时收集一次 eval 的任务项
-    buf: Dict[str, float] = {}
-    needed_metrics = [TASK_SPECS[t]["metric"] for t in tasks]
+    in_edge = False
+    buffer: Dict[str, float] = {}
+    needed_metrics = [TASK_SPECS[task]["metric"] for task in tasks]
 
     def maybe_flush():
-        nonlocal buf
-        if all(k in buf for k in needed_metrics):
-            records.append({
-                "epoch": cur_epoch,
-                **buf
-            })
-            buf = {}
+        nonlocal buffer
+        if all(metric in buffer for metric in needed_metrics):
+            records.append({"epoch": current_epoch, **buffer})
+            buffer = {}
 
-    with log_path.open("r", encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            # epoch 标记
-            m = RE_EPOCH.search(line)
-            if m:
-                try:
-                    cur_epoch = int(m.group(1))
-                except:
-                    cur_epoch = None
+    with log_path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            epoch_match = RE_EPOCH.search(line)
+            if epoch_match:
+                current_epoch = int(epoch_match.group(1))
 
-            # 进入/退出 saliency 与 normals 区块
             if RE_SALIENCY_HEADER.search(line):
-                in_saliency = True
-                in_normals = False
-                in_depth = False
+                in_saliency, in_normals, in_depth, in_edge = True, False, False, False
                 continue
             if RE_NORMALS_HEADER.search(line):
-                in_normals = True
-                in_saliency = False
-                in_depth = False
+                in_saliency, in_normals, in_depth, in_edge = False, True, False, False
                 continue
             if RE_DEPTH_HEADER.search(line):
-                in_depth = True
-                in_saliency = False
-                in_normals = False
+                in_saliency, in_normals, in_depth, in_edge = False, False, True, False
+                continue
+            if RE_EDGE_HEADER.search(line):
+                in_saliency, in_normals, in_depth, in_edge = False, False, False, True
                 continue
 
-            # 直接匹配的两项
-            m = RE_SEMSEG.search(line)
-            if m:
-                buf["semseg_miou"] = float(m.group(1))
+            semseg_match = RE_SEMSEG.search(line)
+            if semseg_match:
+                buffer["semseg_miou"] = float(semseg_match.group(1))
                 maybe_flush()
                 continue
 
-            m = RE_HUMAN.search(line)
-            if m:
-                buf["human_miou"] = float(m.group(1))
+            human_match = RE_HUMAN.search(line)
+            if human_match:
+                buffer["human_miou"] = float(human_match.group(1))
                 maybe_flush()
                 continue
 
-            # saliency 的 mIoU 行只在 saliency 区块内采集，避免与别处 "mIoU:" 混淆
             if in_saliency:
-                m = RE_SALIENCY_MIOU.search(line)
-                if m:
-                    buf["saliency_miou"] = float(m.group(1))
-                    in_saliency = False  # 取到 mIoU 即视为该区块结束
+                saliency_match = RE_SALIENCY_MIOU.search(line)
+                if saliency_match:
+                    buffer["saliency_miou"] = float(saliency_match.group(1))
+                    in_saliency = False
                     maybe_flush()
                     continue
 
-            # normals 的 mean 行只在 normals 区块内采集
             if in_normals:
-                m = RE_NORMALS_MEAN.search(line)
-                if m:
-                    buf["normals_mean"] = float(m.group(1))
+                normals_match = RE_NORMALS_MEAN.search(line)
+                if normals_match:
+                    buffer["normals_mean"] = float(normals_match.group(1))
                     in_normals = False
                     maybe_flush()
                     continue
 
-            # depth 的 rmse 行只在 depth 区块内采集
             if in_depth:
-                m = RE_DEPTH_RMSE.search(line)
-                if m:
-                    buf["depth_rmse"] = float(m.group(1))
+                depth_match = RE_DEPTH_RMSE.search(line)
+                if depth_match:
+                    buffer["depth_rmse"] = float(depth_match.group(1))
                     in_depth = False
                     maybe_flush()
                     continue
 
-    # 收尾（防止日志最后一次 eval 没被 flush）
-    if all(k in buf for k in needed_metrics):
-        records.append({
-            "epoch": cur_epoch,
-            **buf
-        })
+            if in_edge:
+                edge_match = RE_EDGE_ODSF.search(line)
+                if edge_match:
+                    buffer["edge_odsf"] = float(edge_match.group(1))
+                    in_edge = False
+                    maybe_flush()
+                    continue
 
+    if all(metric in buffer for metric in needed_metrics):
+        records.append({"epoch": current_epoch, **buffer})
     return records
+
 
 def main():
     args = parse_args()
-    st = load_st_baseline(args)
-    recs = parse_log(args.log_file, args.tasks)
-    if not recs:
-        raise SystemExit(f"未在日志中解析到任何完整的 eval 记录（所选任务: {args.tasks}）。请检查格式/正则。")
+    baselines = load_st_baseline(args)
+    records = parse_log(args.log_file, args.tasks)
+    if not records:
+        raise SystemExit(f"no complete validation records were parsed for tasks={args.tasks}")
 
-    # 计算 Δm
-    out_rows: List[Tuple[int, float, Dict[str, float]]] = []
-    for r in recs:
-        cur = {TASK_SPECS[t]["metric"]: r[TASK_SPECS[t]["metric"]] for t in args.tasks}
-        d = compute_delta_m(cur, st, args.tasks)
-        out_rows.append((r.get("epoch", -1), d, cur))
+    rows: List[Tuple[int, float, Dict[str, float]]] = []
+    for record in records:
+        current = {TASK_SPECS[task]["metric"]: record[TASK_SPECS[task]["metric"]] for task in args.tasks}
+        rows.append((record.get("epoch", -1), compute_delta_m(current, baselines, args.tasks), current))
 
-    # 输出每次 eval
-    print("Per-eval Δm(%)：")
-    for ep, d, cur in out_rows:
-        ep_str = f"epoch {ep}" if ep is not None and ep >= 0 else "(epoch 未捕获)"
-        metric_str = ", ".join(
-            f"{TASK_SPECS[t]['display']} {cur[TASK_SPECS[t]['metric']]:.4f}" for t in args.tasks
+    print("Per-eval Delta m(%):")
+    for epoch, delta_m, current in rows:
+        epoch_label = f"epoch {epoch}" if epoch is not None and epoch >= 0 else "epoch N/A"
+        metrics = ", ".join(
+            f"{TASK_SPECS[task]['display']} {current[TASK_SPECS[task]['metric']]:.4f}"
+            for task in args.tasks
         )
-        print(f"- {ep_str}: Δm = {d:.3f}% | {metric_str}")
+        print(f"- {epoch_label}: Delta m = {delta_m:.3f}% | {metrics}")
 
-    # 最大值
-    best = max(out_rows, key=lambda x: x[1])
-    bep, bd, bcur = best
-    bep_str = f"{bep}" if bep is not None and bep >= 0 else "N/A"
-    print("\n=== Best Δm(%) ===")
-    print(f"Epoch: {bep_str}")
-    print(f"Δm: {bd:.3f}%")
-    for t in args.tasks:
-        metric = TASK_SPECS[t]["metric"]
-        print(f"{TASK_SPECS[t]['display']}: {bcur[metric]:.4f}")
+    best_epoch, best_delta_m, best_metrics = max(rows, key=lambda row: row[1])
+    print("\n=== Best Delta m(%) ===")
+    print(f"Epoch: {best_epoch if best_epoch is not None and best_epoch >= 0 else 'N/A'}")
+    print(f"Delta m: {best_delta_m:.3f}%")
+    for task in args.tasks:
+        metric = TASK_SPECS[task]["metric"]
+        print(f"{TASK_SPECS[task]['display']}: {best_metrics[metric]:.4f}")
 
-    # 可选导出 CSV
     if args.csv_out is not None:
-        try:
-            import csv
-            with args.csv_out.open("w", newline="", encoding="utf-8") as f:
-                writer = csv.writer(f)
-                metric_headers = [TASK_SPECS[t]["display"].replace(" ", "_") for t in args.tasks]
-                writer.writerow(["epoch", *metric_headers, "Delta_m_percent"])
-                for ep, d, cur in out_rows:
-                    writer.writerow([ep, *[cur[TASK_SPECS[t]["metric"]] for t in args.tasks], d])
-                # ⚠️ 额外写入 best 结果
-                writer.writerow([])
-                writer.writerow([f"BEST(epoch {bep})", *[bcur[TASK_SPECS[t]["metric"]] for t in args.tasks], bd])
+        with args.csv_out.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            headers = [TASK_SPECS[task]["display"].replace(" ", "_") for task in args.tasks]
+            writer.writerow(["epoch", *headers, "Delta_m_percent"])
+            for epoch, delta_m, current in rows:
+                writer.writerow([epoch, *[current[TASK_SPECS[task]["metric"]] for task in args.tasks], delta_m])
+            writer.writerow([])
+            writer.writerow(
+                [
+                    f"BEST(epoch {best_epoch})",
+                    *[best_metrics[TASK_SPECS[task]["metric"]] for task in args.tasks],
+                    best_delta_m,
+                ]
+            )
+        print(f"\nCSV written to: {args.csv_out}")
 
-            print(f"\nCSV 已写出：{args.csv_out}")
-        except Exception as e:
-            print(f"[WARN] 写 CSV 失败：{e}")
 
 if __name__ == "__main__":
     main()

--- a/configs/mtlora/tiny_448/nyud/promlora_tiny_448_r64_prom50_scale4_pertask_nyud.yaml
+++ b/configs/mtlora/tiny_448/nyud/promlora_tiny_448_r64_prom50_scale4_pertask_nyud.yaml
@@ -2,7 +2,7 @@ DATA:
   IMG_SIZE: 448
 MODEL:
   TYPE: swin
-  NAME: promlora_tiny_448_r64_prom60_scale4_pertask_nyud
+  NAME: promlora_tiny_448_r64_prom50_scale4_pertask_nyud
   DROP_PATH_RATE: 0.2
   SWIN:
     EMBED_DIM: 96
@@ -37,7 +37,7 @@ MODEL:
   PROMPT:
     INITIATION: random
     ENABLED: True
-    NUM_TOKENS: 60
+    NUM_TOKENS: 50
     DEEP: True
     DROPOUT: 0.0
   DECODER_HEAD:

--- a/configs/mtlora/tiny_448/pascal/ema_gated_mtlora_tiny_448_r64_ts4_stage_last_shared_bias.yaml
+++ b/configs/mtlora/tiny_448/pascal/ema_gated_mtlora_tiny_448_r64_ts4_stage_last_shared_bias.yaml
@@ -1,0 +1,52 @@
+DATA:
+  IMG_SIZE: 448
+MODEL:
+  TYPE: swin
+  NAME: ema_gated_mtlora_tiny_448_r64_ts4_stage_last_shared_bias
+  DROP_PATH_RATE: 0.2
+  SWIN:
+    EMBED_DIM: 96
+    DEPTHS: [2, 2, 6, 2]
+    NUM_HEADS: [3, 6, 12, 24]
+    WINDOW_SIZE: 7
+  MTLORA:
+    ENABLED: True
+    R: [64, 64, 64, 64]
+    SHARED_SCALE: [4.0]
+    TASK_SCALE: [4.0]
+    DROPOUT: [0.05, 0.05, 0.05, 0.05]
+    TRAINABLE_SCALE_SHARED: False
+    TRAINABLE_SCALE_PER_TASK: False
+    INTERMEDIATE_SPECIALIZATION: False
+    FREEZE_PRETRAINED: True
+    SPLIT_QKV: False
+    QKV_ENABLED: True
+    PROJ_ENABLED: True
+    FC1_ENABLED: True
+    FC2_ENABLED: True
+    DOWNSAMPLER_ENABLED: False
+    EMA_GATE:
+      ENABLED: True
+      GRANULARITY: stage_last
+      EMA_DECAY: 0.9
+      ALPHA_SHARED_INIT: 0.8
+      ALPHA_SPECIFIC_INIT: 0.2
+      ALPHA_MIN: 0.4
+      ALPHA_MAX: 0.9
+      UPDATE_EVERY_EPOCH: 1
+      LOG_HISTORY: True
+    R_PER_TASK:
+      semseg: [4]
+      normals: [4]
+      sal: [4]
+      human_parts: [4]
+      edge: [4]
+      depth: [4]
+      shared: [64]
+  DECODER_HEAD:
+    semseg: hrnet
+    normals: hrnet
+    sal: hrnet
+    human_parts: hrnet
+    edge: hrnet
+    depth: hrnet

--- a/configs/mtlora/tiny_448/pascal/ema_gated_mtlora_tiny_448_r64_ts4_stage_last_slow_ema.yaml
+++ b/configs/mtlora/tiny_448/pascal/ema_gated_mtlora_tiny_448_r64_ts4_stage_last_slow_ema.yaml
@@ -1,0 +1,52 @@
+DATA:
+  IMG_SIZE: 448
+MODEL:
+  TYPE: swin
+  NAME: ema_gated_mtlora_tiny_448_r64_ts4_stage_last_slow_ema
+  DROP_PATH_RATE: 0.2
+  SWIN:
+    EMBED_DIM: 96
+    DEPTHS: [2, 2, 6, 2]
+    NUM_HEADS: [3, 6, 12, 24]
+    WINDOW_SIZE: 7
+  MTLORA:
+    ENABLED: True
+    R: [64, 64, 64, 64]
+    SHARED_SCALE: [4.0]
+    TASK_SCALE: [4.0]
+    DROPOUT: [0.05, 0.05, 0.05, 0.05]
+    TRAINABLE_SCALE_SHARED: False
+    TRAINABLE_SCALE_PER_TASK: False
+    INTERMEDIATE_SPECIALIZATION: False
+    FREEZE_PRETRAINED: True
+    SPLIT_QKV: False
+    QKV_ENABLED: True
+    PROJ_ENABLED: True
+    FC1_ENABLED: True
+    FC2_ENABLED: True
+    DOWNSAMPLER_ENABLED: False
+    EMA_GATE:
+      ENABLED: True
+      GRANULARITY: stage_last
+      EMA_DECAY: 0.99
+      ALPHA_SHARED_INIT: 0.75
+      ALPHA_SPECIFIC_INIT: 0.25
+      ALPHA_MIN: 0.3
+      ALPHA_MAX: 0.85
+      UPDATE_EVERY_EPOCH: 1
+      LOG_HISTORY: True
+    R_PER_TASK:
+      semseg: [4]
+      normals: [4]
+      sal: [4]
+      human_parts: [4]
+      edge: [4]
+      depth: [4]
+      shared: [64]
+  DECODER_HEAD:
+    semseg: hrnet
+    normals: hrnet
+    sal: hrnet
+    human_parts: hrnet
+    edge: hrnet
+    depth: hrnet

--- a/configs/swin/tiny_448/nyud/swin_tiny_patch4_window7_448_nyud_edge.yaml
+++ b/configs/swin/tiny_448/nyud/swin_tiny_patch4_window7_448_nyud_edge.yaml
@@ -1,0 +1,18 @@
+DATA:
+  IMG_SIZE: 448
+MODEL:
+  TYPE: swin
+  NAME: swin_tiny_patch4_window7_448_nyud_edge
+  DROP_PATH_RATE: 0.2
+  SWIN:
+    EMBED_DIM: 96
+    DEPTHS: [2, 2, 6, 2]
+    NUM_HEADS: [3, 6, 12, 24]
+    WINDOW_SIZE: 7
+  DECODER_HEAD:
+    semseg: hrnet
+    normals: hrnet
+    sal: hrnet
+    human_parts: hrnet
+    edge: hrnet
+    depth: hrnet

--- a/evaluation/edge_metrics.py
+++ b/evaluation/edge_metrics.py
@@ -1,0 +1,315 @@
+import csv
+from pathlib import Path
+
+import cv2
+import numpy as np
+from skimage.morphology import disk
+
+
+DEFAULT_THRESHOLDS = np.linspace(1.0, 0.0, 101)
+DEFAULT_TOLERANCE_RATIO = 0.0075
+
+
+def _to_path(path_like):
+    return path_like if isinstance(path_like, Path) else Path(path_like)
+
+
+def _ensure_2d_float(arr):
+    arr = np.asarray(arr)
+    if arr.ndim == 3:
+        if arr.shape[0] == 1:
+            arr = arr[0]
+        elif arr.shape[-1] == 1:
+            arr = arr[..., 0]
+    if arr.ndim != 2:
+        raise ValueError(f"expected a 2D array, got shape {arr.shape}")
+    return arr.astype(np.float32)
+
+
+def _ensure_3d_gt(arr):
+    arr = np.asarray(arr)
+    if arr.ndim == 2:
+        arr = arr[np.newaxis, ...]
+    elif arr.ndim == 3 and arr.shape[-1] == 1:
+        arr = np.transpose(arr, (2, 0, 1))
+    if arr.ndim != 3:
+        raise ValueError(f"expected a 2D or 3D array, got shape {arr.shape}")
+    return arr.astype(np.float32)
+
+
+def _normalize_prob_map(arr):
+    arr = _ensure_2d_float(arr)
+    if arr.max() > 1.0 or arr.min() < 0.0:
+        arr = arr / 255.0
+    return np.clip(arr, 0.0, 1.0)
+
+
+def _normalize_gt_stack(arr):
+    arr = _ensure_3d_gt(arr)
+    if arr.max() > 1.0 or arr.min() < 0.0:
+        arr = arr / 255.0
+    return (arr >= 0.5).astype(np.uint8)
+
+
+def _prediction_candidates(pred_root, image_id):
+    pred_root = _to_path(pred_root)
+    direct = [pred_root / f"{image_id}.npy", pred_root / f"{image_id}.png"]
+    nested = [pred_root / "edge" / f"{image_id}.npy", pred_root / "edge" / f"{image_id}.png"]
+    return nested + direct
+
+
+def _gt_candidates(gt_root, image_id):
+    gt_root = _to_path(gt_root)
+    edge_eval = gt_root / "edge_eval"
+    edge = gt_root / "edge"
+    return {
+        "edge_eval": [edge_eval / f"{image_id}.npz", edge_eval / f"{image_id}.npy"],
+        "edge": [edge / f"{image_id}.npy", edge / f"{image_id}.png"],
+    }
+
+
+def load_prediction_map(path_like):
+    path = _to_path(path_like)
+    if not path.is_file():
+        raise FileNotFoundError(f"prediction file not found: {path}")
+    if path.suffix.lower() == ".npy":
+        return _normalize_prob_map(np.load(path))
+    if path.suffix.lower() == ".png":
+        return _normalize_prob_map(cv2.imread(str(path), cv2.IMREAD_UNCHANGED))
+    raise ValueError(f"unsupported prediction format: {path.suffix}")
+
+
+def resolve_prediction_path(pred_root, image_id):
+    for candidate in _prediction_candidates(pred_root, image_id):
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"missing prediction for {image_id} under {pred_root}")
+
+
+def load_ground_truth_stack(gt_root, image_id):
+    candidates = _gt_candidates(gt_root, image_id)
+
+    for candidate in candidates["edge_eval"]:
+        if not candidate.is_file():
+            continue
+        if candidate.suffix.lower() == ".npz":
+            data = np.load(candidate)
+            if "gts" in data:
+                return _normalize_gt_stack(data["gts"])
+            first_key = next(iter(data.files))
+            return _normalize_gt_stack(data[first_key])
+        return _normalize_gt_stack(np.load(candidate))
+
+    for candidate in candidates["edge"]:
+        if not candidate.is_file():
+            continue
+        if candidate.suffix.lower() == ".npy":
+            return _normalize_gt_stack(np.load(candidate))
+        return _normalize_gt_stack(cv2.imread(str(candidate), cv2.IMREAD_UNCHANGED))
+
+    raise FileNotFoundError(f"missing edge ground truth for {image_id} under {gt_root}")
+
+
+def has_edge_ground_truth(gt_root):
+    gt_root = _to_path(gt_root)
+    return (gt_root / "edge").is_dir() or (gt_root / "edge_eval").is_dir()
+
+
+def collect_prediction_ids(pred_root):
+    pred_root = _to_path(pred_root)
+    edge_root = pred_root / "edge"
+    search_roots = [edge_root] if edge_root.is_dir() else [pred_root]
+
+    image_ids = set()
+    for root in search_roots:
+        for suffix in ("*.npy", "*.png"):
+            for path in root.glob(suffix):
+                image_ids.add(path.stem)
+    return sorted(image_ids)
+
+
+def _resize_prediction(prob_map, shape):
+    if prob_map.shape == shape:
+        return prob_map
+    return cv2.resize(prob_map, shape[::-1], interpolation=cv2.INTER_LINEAR)
+
+
+def _make_kernel(shape, tolerance_ratio):
+    diag = float(np.hypot(shape[0], shape[1]))
+    radius = max(1, int(round(diag * tolerance_ratio)))
+    footprint = disk(radius).astype(np.uint8)
+    if footprint.ndim != 2 or footprint.size == 0:
+        footprint = np.ones((1, 1), dtype=np.uint8)
+    return footprint
+
+
+def _f1(precision, recall):
+    denom = precision + recall
+    if denom <= 0:
+        return 0.0
+    return 2.0 * precision * recall / denom
+
+
+def _boundary_stats(pred_mask, gt_mask, kernel):
+    pred_mask = pred_mask.astype(bool)
+    gt_mask = gt_mask.astype(bool)
+    pred_count = int(pred_mask.sum())
+    gt_count = int(gt_mask.sum())
+
+    if pred_count == 0 and gt_count == 0:
+        return {
+            "tp_pred": 0,
+            "pred_count": 0,
+            "tp_gt": 0,
+            "gt_count": 0,
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0,
+        }
+
+    gt_dilated = cv2.dilate(gt_mask.astype(np.uint8), kernel, iterations=1).astype(bool)
+    pred_dilated = cv2.dilate(pred_mask.astype(np.uint8), kernel, iterations=1).astype(bool)
+    tp_pred = int(np.logical_and(pred_mask, gt_dilated).sum())
+    tp_gt = int(np.logical_and(gt_mask, pred_dilated).sum())
+
+    precision = tp_pred / pred_count if pred_count > 0 else 0.0
+    recall = tp_gt / gt_count if gt_count > 0 else 1.0
+
+    return {
+        "tp_pred": tp_pred,
+        "pred_count": pred_count,
+        "tp_gt": tp_gt,
+        "gt_count": gt_count,
+        "precision": precision,
+        "recall": recall,
+        "f1": _f1(precision, recall),
+    }
+
+
+def _best_stats_for_threshold(prob_map, gt_stack, threshold, kernel):
+    pred_mask = prob_map >= threshold
+    best = None
+    for gt_mask in gt_stack:
+        stats = _boundary_stats(pred_mask, gt_mask, kernel)
+        if best is None or stats["f1"] > best["f1"]:
+            best = stats
+    return best
+
+
+def evaluate_edge_predictions(predictions, ground_truths, thresholds=None, tolerance_ratio=DEFAULT_TOLERANCE_RATIO):
+    if thresholds is None:
+        thresholds = DEFAULT_THRESHOLDS
+    thresholds = [float(t) for t in thresholds]
+
+    image_ids = sorted(predictions.keys())
+    if not image_ids:
+        raise ValueError("no edge predictions were provided")
+
+    curves = []
+    per_image_best = []
+
+    for threshold in thresholds:
+        total_tp_pred = 0
+        total_pred = 0
+        total_tp_gt = 0
+        total_gt = 0
+
+        for image_id in image_ids:
+            prob_map = predictions[image_id]
+            gt_stack = ground_truths[image_id]
+            gt_shape = tuple(gt_stack.shape[-2:])
+            prob_map = _resize_prediction(prob_map, gt_shape)
+            kernel = _make_kernel(gt_shape, tolerance_ratio)
+            stats = _best_stats_for_threshold(prob_map, gt_stack, threshold, kernel)
+            total_tp_pred += stats["tp_pred"]
+            total_pred += stats["pred_count"]
+            total_tp_gt += stats["tp_gt"]
+            total_gt += stats["gt_count"]
+
+        precision = total_tp_pred / total_pred if total_pred > 0 else 0.0
+        recall = total_tp_gt / total_gt if total_gt > 0 else 1.0
+        curves.append(
+            {
+                "threshold": threshold,
+                "precision": precision,
+                "recall": recall,
+                "f1": _f1(precision, recall),
+            }
+        )
+
+    for image_id in image_ids:
+        prob_map = predictions[image_id]
+        gt_stack = ground_truths[image_id]
+        gt_shape = tuple(gt_stack.shape[-2:])
+        prob_map = _resize_prediction(prob_map, gt_shape)
+        kernel = _make_kernel(gt_shape, tolerance_ratio)
+        best = {"threshold": None, "f1": -1.0}
+        for threshold in thresholds:
+            stats = _best_stats_for_threshold(prob_map, gt_stack, threshold, kernel)
+            if stats["f1"] > best["f1"]:
+                best = {"threshold": threshold, "f1": stats["f1"]}
+        per_image_best.append(best)
+
+    precisions = np.array([row["precision"] for row in curves], dtype=np.float64)
+    recalls = np.array([row["recall"] for row in curves], dtype=np.float64)
+    f1_scores = np.array([row["f1"] for row in curves], dtype=np.float64)
+    best_idx = int(np.argmax(f1_scores))
+
+    ap_precisions = precisions.copy()
+    ap_recalls = recalls.copy()
+    order = np.argsort(ap_recalls)
+    ap_precisions = ap_precisions[order]
+    ap_recalls = ap_recalls[order]
+    ap_precisions = np.concatenate(([ap_precisions[0]], ap_precisions, [0.0]))
+    ap_recalls = np.concatenate(([0.0], ap_recalls, [1.0]))
+    for idx in range(len(ap_precisions) - 2, -1, -1):
+        ap_precisions[idx] = max(ap_precisions[idx], ap_precisions[idx + 1])
+    ap = float(np.sum((ap_recalls[1:] - ap_recalls[:-1]) * ap_precisions[1:]))
+
+    return {
+        "odsF": float(f1_scores[best_idx]),
+        "oisF": float(np.mean([row["f1"] for row in per_image_best])),
+        "ap": ap,
+        "best_threshold": float(curves[best_idx]["threshold"]),
+        "num_images": len(image_ids),
+        "thresholds": [row["threshold"] for row in curves],
+        "precision": [row["precision"] for row in curves],
+        "recall": [row["recall"] for row in curves],
+        "f1": [row["f1"] for row in curves],
+    }
+
+
+def evaluate_edge_directory(pred_root, gt_root, image_ids=None, thresholds=None, tolerance_ratio=DEFAULT_TOLERANCE_RATIO):
+    pred_root = _to_path(pred_root)
+    gt_root = _to_path(gt_root)
+    if image_ids is None:
+        image_ids = collect_prediction_ids(pred_root)
+    if not image_ids:
+        raise ValueError(f"no edge predictions found under {pred_root}")
+
+    predictions = {}
+    ground_truths = {}
+    for image_id in image_ids:
+        predictions[image_id] = load_prediction_map(resolve_prediction_path(pred_root, image_id))
+        ground_truths[image_id] = load_ground_truth_stack(gt_root, image_id)
+
+    return evaluate_edge_predictions(
+        predictions=predictions,
+        ground_truths=ground_truths,
+        thresholds=thresholds,
+        tolerance_ratio=tolerance_ratio,
+    )
+
+
+def write_pr_csv(path_like, edge_results):
+    path = _to_path(path_like)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["threshold", "precision", "recall", "f1"])
+        for threshold, precision, recall, f1_score in zip(
+            edge_results["thresholds"],
+            edge_results["precision"],
+            edge_results["recall"],
+            edge_results["f1"],
+        ):
+            writer.writerow([threshold, precision, recall, f1_score])

--- a/evaluation/eval_depth.py
+++ b/evaluation/eval_depth.py
@@ -104,13 +104,15 @@ class DepthMeter(object):
         return eval_result
         
 
-def eval_depth_predictions(database, save_dir, overfit=False):
+def eval_depth_predictions(database, save_dir, gt_root=None, overfit=False):
 
     # Dataloaders
     if database == 'NYUD':
-        from data.nyud import NYUD_MT 
+        from data.mtl_ds import NYUD_MT
+        if gt_root is None:
+            raise ValueError('gt_root must be provided for NYUD depth evaluation')
         gt_set = 'val'
-        db = NYUD_MT(split=gt_set, do_depth=True, overfit=overfit)
+        db = NYUD_MT(root=gt_root, split=gt_set, do_depth=True, overfit=overfit)
     
     else:
         raise NotImplementedError

--- a/evaluation/eval_edge.py
+++ b/evaluation/eval_edge.py
@@ -2,13 +2,13 @@
 # Authors: Simon Vandenhende
 # Licensed under the CC BY-NC 4.0 license (https://creativecommons.org/licenses/by-nc/4.0/)
 
-import os
-import glob
 import json
-import torch
-import numpy as np
 import logging
-from utils import mkdir_if_missing
+import os
+
+import torch
+
+from evaluation.edge_metrics import evaluate_edge_directory, write_pr_csv
 from mtl_loss_schemes import BalancedCrossEntropyLoss
 
 eval_logger = logging.getLogger('eval')
@@ -16,29 +16,65 @@ eval_logger = logging.getLogger('eval')
 
 class EdgeMeter(object):
     def __init__(self, pos_weight):
-        self.loss = 0
-        self.n = 0
         self.loss_function = BalancedCrossEntropyLoss(
             size_average=True, pos_weight=pos_weight)
+        self.formal_results = None
+        self.reset()
 
     @torch.no_grad()
     def update(self, pred, gt):
         gt = gt.squeeze()
-        pred = pred.float().squeeze() / 255.
+        pred = pred.float().squeeze() / 255.0
         loss = self.loss_function(pred, gt).item()
         numel = gt.numel()
         self.n += numel
         self.loss += numel * loss
 
     def reset(self):
-        self.loss = 0
+        self.loss = 0.0
         self.n = 0
+        self.formal_results = None
+
+    def set_formal_results(self, results):
+        self.formal_results = dict(results) if results is not None else None
 
     def get_score(self, verbose=True):
-        eval_dict = {'loss': self.loss / self.n}
+        eval_dict = {"loss": self.loss / self.n if self.n > 0 else 0.0}
+        if self.formal_results:
+            for key in ("odsF", "oisF", "ap", "best_threshold", "num_images"):
+                if key in self.formal_results:
+                    eval_dict[key] = self.formal_results[key]
 
         if verbose:
-            eval_logger.info('\nEdge Detection Evaluation')
-            eval_logger.info('Edge Detection Loss %.3f' % (eval_dict['loss']))
+            eval_logger.info("\nEdge Detection Evaluation")
+            eval_logger.info("loss: %.6f" % eval_dict["loss"])
+            if "odsF" in eval_dict:
+                eval_logger.info("odsF: %.6f" % eval_dict["odsF"])
+                eval_logger.info("oisF: %.6f" % eval_dict["oisF"])
+                eval_logger.info("ap: %.6f" % eval_dict["ap"])
 
         return eval_dict
+
+
+def eval_edge_predictions(database, save_dir, gt_root=None, overfit=False, write_outputs=True):
+    del overfit
+    if database != "NYUD":
+        raise NotImplementedError("formal edge evaluation is only implemented for NYUD")
+    if gt_root is None:
+        raise ValueError("gt_root must be provided for NYUD edge evaluation")
+
+    eval_logger.info("Evaluate the saved images (edge)")
+    eval_results = evaluate_edge_directory(pred_root=save_dir, gt_root=gt_root)
+
+    if write_outputs:
+        base_name = database + "_" + "test" + "_edge"
+        json_path = os.path.join(save_dir, base_name + ".json")
+        csv_path = os.path.join(save_dir, base_name + "_pr.csv")
+        with open(json_path, "w", encoding="utf-8") as handle:
+            json.dump(eval_results, handle, indent=2)
+        write_pr_csv(csv_path, eval_results)
+
+    eval_logger.info("odsF: %.6f" % eval_results["odsF"])
+    eval_logger.info("oisF: %.6f" % eval_results["oisF"])
+    eval_logger.info("ap: %.6f" % eval_results["ap"])
+    return eval_results

--- a/evaluation/eval_human_parts.py
+++ b/evaluation/eval_human_parts.py
@@ -125,14 +125,16 @@ class HumanPartsMeter(object):
         return eval_result
 
 
-def eval_human_parts_predictions(database, save_dir, overfit=False):
+def eval_human_parts_predictions(database, save_dir, gt_root=None, overfit=False):
     """ Evaluate the human parts predictions that are stored in the save dir """
 
     # Dataloaders
     if database == 'PASCALContext':
-        from data.pascal_context import PASCALContext
+        from data.mtl_ds import PASCALContext
+        if gt_root is None:
+            raise ValueError('gt_root must be provided for PASCAL human-parts evaluation')
         gt_set = 'val'
-        db = PASCALContext(split=gt_set, do_edge=False, do_human_parts=True, do_semseg=False,
+        db = PASCALContext(root=gt_root, split=gt_set, do_edge=False, do_human_parts=True, do_semseg=False,
                                           do_normals=False, do_sal=False, overfit=overfit)
     
     else:

--- a/evaluation/eval_semseg.py
+++ b/evaluation/eval_semseg.py
@@ -146,27 +146,31 @@ class SemsegMeter(object):
         return eval_result
 
 
-def eval_semseg_predictions(database, save_dir, overfit=False):
+def eval_semseg_predictions(database, save_dir, gt_root=None, overfit=False):
     """ Evaluate the segmentation maps that are stored in the save dir """
 
     # Dataloaders
     if database == 'PASCALContext':
-        from data.pascal_context import PASCALContext
+        from data.mtl_ds import PASCALContext
+        if gt_root is None:
+            raise ValueError('gt_root must be provided for PASCAL semantic segmentation evaluation')
         n_classes = 20
         cat_names = VOC_CATEGORY_NAMES
         has_bg = True
         gt_set = 'val'
-        db = PASCALContext(split=gt_set, do_edge=False, do_human_parts=False, do_semseg=True,
+        db = PASCALContext(root=gt_root, split=gt_set, do_edge=False, do_human_parts=False, do_semseg=True,
                            do_normals=False, overfit=overfit)
         ignore_index = 255
 
     elif database == 'NYUD':
-        from data.nyud import NYUD_MT
+        from data.mtl_ds import NYUD_MT
+        if gt_root is None:
+            raise ValueError('gt_root must be provided for NYUD semantic segmentation evaluation')
         n_classes = 40
         cat_names = NYU_CATEGORY_NAMES
         has_bg = False
         gt_set = 'val'
-        db = NYUD_MT(split=gt_set, do_semseg=True, overfit=overfit)
+        db = NYUD_MT(root=gt_root, split=gt_set, do_semseg=True, overfit=overfit)
         ignore_index = 255
 
     else:

--- a/evaluation/evaluate_utils.py
+++ b/evaluation/evaluate_utils.py
@@ -73,8 +73,13 @@ def calculate_multi_task_performance(eval_dict, single_task_dict):
         elif task == 'normals':  # mean error lower is better
             mtl_performance -= (mtl['mean'] - stl['mean'])/stl['mean']
 
-        elif task == 'edge':  # odsF higher is better
-            mtl_performance += (mtl['odsF'] - stl['odsF'])/stl['odsF']
+        elif task == 'edge':
+            if 'odsF' in mtl and 'odsF' in stl:  # preferred formal metric
+                mtl_performance += (mtl['odsF'] - stl['odsF'])/stl['odsF']
+            elif 'loss' in mtl and 'loss' in stl:  # fallback for legacy runs
+                mtl_performance -= (mtl['loss'] - stl['loss'])/stl['loss']
+            else:
+                raise KeyError('edge metrics must contain odsF or loss')
 
         else:
             raise NotImplementedError
@@ -106,12 +111,9 @@ def get_single_task_meter(config, task, database="NYUD"):
         from evaluation.eval_depth import DepthMeter
         return DepthMeter()
 
-    # Single task performance meter uses the loss (True evaluation is based on seism evaluation)
     elif task == 'edge':
         from evaluation.eval_edge import EdgeMeter
-        # TODO: get edge_w from task config
         return EdgeMeter(pos_weight=0.95)
-        # return EdgeMeter()
 
     else:
         raise NotImplementedError

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ import random
 import argparse
 import datetime
 import math
+import shutil
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -40,6 +41,7 @@ from utils import load_checkpoint, load_pretrained, save_checkpoint, NativeScale
 
 from mtl_loss_schemes import MultiTaskLoss, get_loss
 from evaluation.evaluate_utils import PerformanceMeter, get_output
+from evaluation.eval_edge import eval_edge_predictions
 from ptflops import get_model_complexity_info
 from models.lora import mark_only_lora_as_trainable
 
@@ -360,6 +362,34 @@ def main(config):
     total_time = time.perf_counter() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     logger.info('Training time {}'.format(total_time_str))
+
+
+def _get_dist_rank():
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_rank()
+    return 0
+
+
+def _prepare_edge_eval_cache(output_dir, epoch):
+    cache_dir = os.path.join(output_dir, "__edge_eval_cache__", f"epoch_{int(epoch):04d}")
+    if os.path.isdir(cache_dir):
+        shutil.rmtree(cache_dir)
+    os.makedirs(os.path.join(cache_dir, "edge"), exist_ok=True)
+    return cache_dir
+
+
+def _save_edge_predictions(cache_dir, image_ids, edge_logits):
+    edge_probs = torch.sigmoid(edge_logits.detach()).float().cpu().numpy()
+    if isinstance(image_ids, str):
+        image_ids = [image_ids]
+    else:
+        image_ids = list(image_ids)
+
+    for index, image_id in enumerate(image_ids):
+        np.save(
+            os.path.join(cache_dir, "edge", f"{image_id}.npy"),
+            edge_probs[index, 0].astype(np.float32),
+        )
 
 
 def _is_per_task_parameter(name, tasks):
@@ -684,7 +714,7 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
                 scores_logs["train/tasks/sal/Beta maxF"] = scores['sal']['Beta maxF']
                 scores_logs["train/tasks/sal/mIoU"] = scores['sal']['mIoU']
             if 'edge' in loss_dict:
-                scores_logs["train/tasks/sal/loss"] = scores['edge']['loss']
+                scores_logs["train/tasks/edge/loss"] = scores['edge']['loss']
             if 'depth' in loss_dict:
                 scores_logs["train/tasks/depth/rmse"] = scores['depth']['rmse']
                 scores_logs["train/tasks/depth/log_rmse"] = scores['depth']['log_rmse']
@@ -700,10 +730,17 @@ def train_one_epoch(config, model, criterion, data_loader, optimizer, epoch, mix
 
 @torch.no_grad()
 def validate(config, data_loader, model, epoch):
-    """ Evaluate model in an online fashion without storing the predictions to disk """
+    """Evaluate the model online and save temporary edge predictions when needed."""
     tasks = config.TASKS
     performance_meter = PerformanceMeter(config, config.DATA.DBNAME)
     loss_meter = AverageMeter()
+    rank = _get_dist_rank()
+    edge_eval_dir = None
+    should_run_formal_edge_eval = (
+        "edge" in tasks and config.DATA.DBNAME == "NYUD" and rank == 0
+    )
+    if should_run_formal_edge_eval:
+        edge_eval_dir = _prepare_edge_eval_cache(config.OUTPUT, epoch)
 
     loss_ft = torch.nn.ModuleDict(
         {task: get_loss(config['TASKS_CONFIG'], task, config) for task in config.TASKS})
@@ -744,6 +781,8 @@ def validate(config, data_loader, model, epoch):
         processed_output = {t: get_output(
             output[t], t) for t in tasks}
         performance_meter.update(processed_output, targets)
+        if edge_eval_dir is not None:
+            _save_edge_predictions(edge_eval_dir, batch["meta"]["image"], output["edge"])
         if wandb_available:
             metrics = {
                 "val/epoch_ndx": epoch,
@@ -758,7 +797,21 @@ def validate(config, data_loader, model, epoch):
 
     logger.info(f"val loss {loss_meter.val:.4f} ({loss_meter.avg:.4f})\t")
 
-    eval_results = performance_meter.get_score(verbose=True)
+    try:
+        if edge_eval_dir is not None:
+            formal_edge_results = eval_edge_predictions(
+                database="NYUD",
+                save_dir=edge_eval_dir,
+                gt_root=config.DATA.DATA_PATH,
+                write_outputs=False,
+            )
+            performance_meter.meters["edge"].set_formal_results(formal_edge_results)
+
+        eval_results = performance_meter.get_score(verbose=True)
+    finally:
+        if edge_eval_dir is not None and os.path.isdir(edge_eval_dir):
+            shutil.rmtree(edge_eval_dir, ignore_errors=True)
+
     epoch_time = time.perf_counter() - start
     logger.info(
         f"eval takes {datetime.timedelta(seconds=int(epoch_time))}")
@@ -780,7 +833,11 @@ def validate(config, data_loader, model, epoch):
             scores_logs["val/tasks/sal/Beta maxF"] = eval_results['sal']['Beta maxF']
             scores_logs["val/tasks/sal/mIoU"] = eval_results['sal']['mIoU']
         if 'edge' in eval_results:
-            scores_logs["val/tasks/sal/loss"] = eval_results['edge']['loss']
+            scores_logs["val/tasks/edge/loss"] = eval_results['edge']['loss']
+            if 'odsF' in eval_results['edge']:
+                scores_logs["val/tasks/edge/odsF"] = eval_results['edge']['odsF']
+                scores_logs["val/tasks/edge/oisF"] = eval_results['edge']['oisF']
+                scores_logs["val/tasks/edge/ap"] = eval_results['edge']['ap']
         if 'depth' in eval_results:
             scores_logs["val/tasks/depth/rmse"] = eval_results['depth']['rmse']
             scores_logs["val/tasks/depth/log_rmse"] = eval_results['depth']['log_rmse']

--- a/rl_agent.py
+++ b/rl_agent.py
@@ -8,7 +8,7 @@ TASK_METRIC_INFO = {
     'semseg': ('mIoU', True),
     'human_parts': ('mIoU', True),
     'sal': ('mIoU', True),
-    'edge': ('loss', False),
+    'edge': ('odsF', True),
     'depth': ('rmse', False),
     'normals': ('rmse', False),
 }
@@ -22,7 +22,10 @@ def extract_task_metrics(eval_results, tasks):
     """
     metrics = {}
     for t in tasks:
-        key, higher_is_better = TASK_METRIC_INFO.get(t, ('mIoU', True))
+        if t == 'edge' and t in eval_results and 'odsF' not in eval_results[t]:
+            key, higher_is_better = ('loss', False)
+        else:
+            key, higher_is_better = TASK_METRIC_INFO.get(t, ('mIoU', True))
         if t in eval_results and key in eval_results[t]:
             val = eval_results[t][key]
             metrics[t] = val if higher_is_better else -val

--- a/scripts/derive_nyud_edge_from_semseg.py
+++ b/scripts/derive_nyud_edge_from_semseg.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.prepare_nyudv2 import derive_edge_from_segmentation, load_segmentation_mask
+
+
+def ensure_empty_dir(path: Path, overwrite: bool) -> None:
+    if path.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"Destination {path} already exists. Use --overwrite to replace it."
+            )
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def collect_segmentation_files(segmentation_dir: Path):
+    files = sorted(segmentation_dir.glob("*.png"))
+    if not files:
+        raise FileNotFoundError(f"no segmentation PNG files found under {segmentation_dir}")
+    return files
+
+
+def derive_edge_directory(segmentation_dir: Path, output_dir: Path, overwrite: bool = False):
+    segmentation_dir = Path(segmentation_dir)
+    output_dir = Path(output_dir)
+    ensure_empty_dir(output_dir, overwrite)
+
+    total_nonzero = 0
+    segmentation_files = collect_segmentation_files(segmentation_dir)
+    for seg_path in segmentation_files:
+        edge = derive_edge_from_segmentation(load_segmentation_mask(seg_path)).astype(np.float32)
+        np.save(output_dir / f"{seg_path.stem}.npy", edge)
+        total_nonzero += int(edge.sum())
+
+    return {
+        "num_files": len(segmentation_files),
+        "total_nonzero": total_nonzero,
+        "output_dir": output_dir,
+    }
+
+
+def swap_edge_directory(dataset_root: Path, derived_edge_dir: Path, backup_name: str):
+    dataset_root = Path(dataset_root)
+    derived_edge_dir = Path(derived_edge_dir)
+    edge_dir = dataset_root / "edge"
+    backup_dir = dataset_root / backup_name
+
+    if backup_dir.exists():
+        raise FileExistsError(
+            f"backup directory already exists: {backup_dir}. Move or remove it before replacing edge."
+        )
+
+    if edge_dir.exists():
+        edge_dir.rename(backup_dir)
+
+    derived_edge_dir.rename(edge_dir)
+    return {
+        "edge_dir": edge_dir,
+        "backup_dir": backup_dir if backup_dir.exists() else None,
+    }
+
+
+def derive_edges_for_prepared_dataset(
+    dataset_root: Path,
+    output_dir: Path = None,
+    replace_edge: bool = False,
+    backup_name: str = "edge_zero_backup",
+    overwrite: bool = False,
+):
+    dataset_root = Path(dataset_root)
+    segmentation_dir = dataset_root / "segmentation"
+    if not segmentation_dir.is_dir():
+        raise FileNotFoundError(f"missing segmentation directory: {segmentation_dir}")
+
+    if output_dir is None:
+        output_dir = dataset_root / "__edge_from_semseg_tmp__"
+    else:
+        output_dir = Path(output_dir)
+
+    edge_dir = dataset_root / "edge"
+    if replace_edge and output_dir.resolve() == edge_dir.resolve():
+        raise ValueError("--output-dir must differ from dataset_root/edge when --replace-edge is enabled")
+
+    results = derive_edge_directory(segmentation_dir, output_dir, overwrite=overwrite)
+
+    if replace_edge:
+        results.update(swap_edge_directory(dataset_root, output_dir, backup_name))
+
+    return results
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Derive NYUD edge labels directly from a prepared dataset root's segmentation folder."
+    )
+    parser.add_argument(
+        "--dataset-root",
+        type=Path,
+        required=True,
+        help="Prepared NYUD dataset root containing segmentation/ and optionally edge/.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory to write derived edge .npy files. Defaults to dataset_root/__edge_from_semseg_tmp__.",
+    )
+    parser.add_argument(
+        "--replace-edge",
+        action="store_true",
+        help="Replace dataset_root/edge by the derived output after creation.",
+    )
+    parser.add_argument(
+        "--backup-name",
+        type=str,
+        default="edge_zero_backup",
+        help="Backup directory name used when --replace-edge is set.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the output directory if it already exists.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    results = derive_edges_for_prepared_dataset(
+        dataset_root=args.dataset_root,
+        output_dir=args.output_dir,
+        replace_edge=args.replace_edge,
+        backup_name=args.backup_name,
+        overwrite=args.overwrite,
+    )
+    print(f"Derived {results['num_files']} edge maps with {results['total_nonzero']} positive pixels in total.")
+    if "edge_dir" in results:
+        print(f"Active edge directory: {results['edge_dir']}")
+    else:
+        print(f"Output edge directory: {results['output_dir']}")
+    if results.get("backup_dir") is not None:
+        print(f"Backup edge directory: {results['backup_dir']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_edge_predictions.py
+++ b/scripts/eval_edge_predictions.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from evaluation.eval_edge import eval_edge_predictions
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Evaluate saved edge predictions.")
+    parser.add_argument(
+        "--dataset",
+        choices=["nyud"],
+        default="nyud",
+        help="Dataset used to resolve GT semantics.",
+    )
+    parser.add_argument(
+        "--pred-dir",
+        type=Path,
+        required=True,
+        help="Prediction directory. Expected files live in pred-dir/edge/ by default.",
+    )
+    parser.add_argument(
+        "--gt-root",
+        type=Path,
+        required=True,
+        help="Prepared dataset root containing edge/ and optionally edge_eval/.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    database = "NYUD" if args.dataset.lower() == "nyud" else args.dataset
+    results = eval_edge_predictions(
+        database=database,
+        save_dir=str(args.pred_dir),
+        gt_root=str(args.gt_root),
+        write_outputs=True,
+    )
+    summary = {key: results[key] for key in ("odsF", "oisF", "ap", "best_threshold", "num_images")}
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_nyudv2.py
+++ b/scripts/prepare_nyudv2.py
@@ -3,9 +3,14 @@
 import argparse
 import shutil
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 import numpy as np
 from PIL import Image
+from skimage.morphology import thin
+
+
+SUPPORTED_EDGE_FORMATS = ("auto", "png", "npy", "npz")
 
 
 def parse_args():
@@ -35,6 +40,24 @@ def parse_args():
         choices=["test", "train"],
         default="test",
         help="If splits.mat does not contain val, which split to copy for val.",
+    )
+    parser.add_argument(
+        "--edge-source",
+        choices=["auto", "real", "derived"],
+        default="auto",
+        help="How to build NYUD edge annotations.",
+    )
+    parser.add_argument(
+        "--edge-root",
+        type=Path,
+        default=None,
+        help="Optional real edge GT root. Used when --edge-source is auto or real.",
+    )
+    parser.add_argument(
+        "--edge-format",
+        choices=SUPPORTED_EDGE_FORMATS,
+        default="auto",
+        help="Format used under --edge-root. auto tries png/npy/npz.",
     )
     parser.add_argument(
         "--overwrite",
@@ -79,11 +102,11 @@ def resolve_ids_from_indices(indices):
     return ids
 
 
-def collect_ids_from_dir(split_dir: Path) -> list[str]:
+def collect_ids_from_dir(split_dir: Path) -> List[str]:
     return sorted(p.stem for p in split_dir.glob("*.png"))
 
 
-def write_split_file(path: Path, ids: list[str]) -> None:
+def write_split_file(path: Path, ids: List[str]) -> None:
     with path.open("w", encoding="utf-8") as handle:
         handle.write("\n".join(ids))
 
@@ -98,27 +121,179 @@ def convert_depth_to_npy(src: Path, dst: Path) -> None:
     np.save(dst, depth)
 
 
-def ensure_edge_placeholder(dst: Path, shape):
-    edge = np.zeros(shape[:2], dtype=np.float32)
-    np.save(dst, edge)
+def load_segmentation_mask(path: Path) -> np.ndarray:
+    return np.array(Image.open(path), dtype=np.int32)
+
+
+def derive_edge_from_segmentation(segmentation: np.ndarray) -> np.ndarray:
+    segmentation = np.asarray(segmentation)
+    if segmentation.ndim != 2:
+        raise ValueError(f"expected a 2D segmentation map, got {segmentation.shape}")
+
+    valid = (segmentation > 0) & (segmentation < 255)
+    edge = np.zeros_like(segmentation, dtype=bool)
+
+    horizontal = (
+        valid[:, :-1]
+        & valid[:, 1:]
+        & (segmentation[:, :-1] != segmentation[:, 1:])
+    )
+    vertical = (
+        valid[:-1, :]
+        & valid[1:, :]
+        & (segmentation[:-1, :] != segmentation[1:, :])
+    )
+
+    edge[:, :-1] |= horizontal
+    edge[:, 1:] |= horizontal
+    edge[:-1, :] |= vertical
+    edge[1:, :] |= vertical
+
+    return thin(edge).astype(np.float32)
+
+
+def _normalize_edge_stack(edge_stack: np.ndarray) -> np.ndarray:
+    edge_stack = np.asarray(edge_stack)
+    if edge_stack.ndim == 2:
+        edge_stack = edge_stack[np.newaxis, ...]
+    if edge_stack.ndim == 3 and edge_stack.shape[-1] == 1:
+        edge_stack = np.transpose(edge_stack, (2, 0, 1))
+    if edge_stack.ndim != 3:
+        raise ValueError(f"expected a 2D or 3D edge stack, got {edge_stack.shape}")
+    if edge_stack.max() > 1.0 or edge_stack.min() < 0.0:
+        edge_stack = edge_stack / 255.0
+    return (edge_stack >= 0.5).astype(np.float32)
+
+
+def fuse_edge_annotations(edge_stack: np.ndarray) -> np.ndarray:
+    edge_stack = _normalize_edge_stack(edge_stack)
+    votes = edge_stack.sum(axis=0)
+    threshold = edge_stack.shape[0] // 2 + 1
+    return (votes >= threshold).astype(np.float32)
+
+
+def _load_edge_stack(path: Path) -> np.ndarray:
+    suffix = path.suffix.lower()
+    if suffix == ".npz":
+        data = np.load(path)
+        if "gts" in data:
+            return _normalize_edge_stack(data["gts"])
+        first_key = next(iter(data.files))
+        return _normalize_edge_stack(data[first_key])
+    if suffix == ".npy":
+        return _normalize_edge_stack(np.load(path))
+    if suffix == ".png":
+        return _normalize_edge_stack(np.array(Image.open(path)))
+    raise ValueError(f"unsupported edge stack format: {path.suffix}")
+
+
+def _allowed_suffixes(edge_format: str) -> Tuple[str, ...]:
+    if edge_format == "auto":
+        return (".png", ".npy", ".npz")
+    return (f".{edge_format}",)
+
+
+def _collect_multi_annotation_paths(base: Path, sample_id: str, allowed_suffixes: Tuple[str, ...]) -> List[Path]:
+    matches = []
+    for suffix in allowed_suffixes:
+        matches.extend(sorted(base.glob(f"{sample_id}_*{suffix}")))
+        matches.extend(sorted(base.glob(f"{sample_id}-*{suffix}")))
+    deduped = []
+    seen = set()
+    for path in matches:
+        if path not in seen:
+            deduped.append(path)
+            seen.add(path)
+    return deduped
+
+
+def find_real_edge_source(edge_root: Path, split_name: str, sample_id: str, edge_format: str):
+    if edge_root is None:
+        return None
+
+    allowed_suffixes = _allowed_suffixes(edge_format)
+    search_roots = [edge_root / split_name, edge_root]
+
+    for base in search_roots:
+        if not base.exists():
+            continue
+
+        sample_dir = base / sample_id
+        if sample_dir.is_dir():
+            files = [
+                path
+                for path in sorted(sample_dir.iterdir())
+                if path.is_file() and path.suffix.lower() in allowed_suffixes
+            ]
+            if files:
+                return files
+
+        for suffix in allowed_suffixes:
+            candidate = base / f"{sample_id}{suffix}"
+            if candidate.is_file():
+                return candidate
+
+        multi = _collect_multi_annotation_paths(base, sample_id, allowed_suffixes)
+        if multi:
+            return multi
+
+    return None
+
+
+def load_real_edge_stack(edge_root: Path, split_name: str, sample_id: str, edge_format: str):
+    source = find_real_edge_source(edge_root, split_name, sample_id, edge_format)
+    if source is None:
+        return None
+
+    if isinstance(source, list):
+        stacks = []
+        for path in source:
+            stacks.extend(list(_normalize_edge_stack(_load_edge_stack(path))))
+        return _normalize_edge_stack(np.stack(stacks, axis=0))
+
+    return _load_edge_stack(source)
+
+
+def write_edge_targets(edge_dst_file: Path, edge_eval_dst_file: Path, edge_stack: np.ndarray) -> None:
+    edge_stack = _normalize_edge_stack(edge_stack)
+    edge_dst_file.parent.mkdir(parents=True, exist_ok=True)
+    np.save(edge_dst_file, fuse_edge_annotations(edge_stack).astype(np.float32))
+
+    if edge_stack.shape[0] > 1:
+        edge_eval_dst_file.parent.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(edge_eval_dst_file, gts=edge_stack.astype(np.float32))
+
+
+def resolve_source_split(src_root: Path, split_name: str, val_from: str) -> str:
+    candidate = src_root / "image" / split_name
+    if candidate.is_dir():
+        return split_name
+    if split_name == "val":
+        return val_from
+    return split_name
 
 
 def prepare_split(
     split_name: str,
-    ids: list[str],
+    source_split_name: str,
+    ids: List[str],
     src_root: Path,
     dst_root: Path,
+    edge_source: str,
+    edge_root: Optional[Path],
+    edge_format: str,
 ) -> None:
-    image_src_dir = src_root / "image" / split_name
-    depth_src_dir = src_root / "depth" / split_name
-    normal_src_dir = src_root / "normal" / split_name
-    seg_src_dir = src_root / "seg40" / split_name
+    image_src_dir = src_root / "image" / source_split_name
+    depth_src_dir = src_root / "depth" / source_split_name
+    normal_src_dir = src_root / "normal" / source_split_name
+    seg_src_dir = src_root / "seg40" / source_split_name
 
     images_dst = dst_root / "images"
     depth_dst = dst_root / "depth"
     normals_dst = dst_root / "normals"
     seg_dst = dst_root / "segmentation"
     edge_dst = dst_root / "edge"
+    edge_eval_dst = dst_root / "edge_eval"
 
     for folder in [images_dst, depth_dst, normals_dst, seg_dst, edge_dst]:
         folder.mkdir(parents=True, exist_ok=True)
@@ -134,6 +309,7 @@ def prepare_split(
         normal_dst = normals_dst / f"{sample_id}.npy"
         seg_dst_file = seg_dst / f"{sample_id}.png"
         edge_dst_file = edge_dst / f"{sample_id}.npy"
+        edge_eval_dst_file = edge_eval_dst / f"{sample_id}.npz"
 
         convert_image_to_jpg(image_src, image_dst)
         convert_depth_to_npy(depth_src, depth_dst_file)
@@ -143,15 +319,31 @@ def prepare_split(
         if not seg_dst_file.exists():
             shutil.copy2(seg_src, seg_dst_file)
 
-        if not edge_dst_file.exists():
-            img = np.array(Image.open(image_src))
-            ensure_edge_placeholder(edge_dst_file, img.shape)
+        real_edge_stack = None
+        if edge_source in {"auto", "real"}:
+            real_edge_stack = load_real_edge_stack(edge_root, source_split_name, sample_id, edge_format)
+
+        if real_edge_stack is not None:
+            write_edge_targets(edge_dst_file, edge_eval_dst_file, real_edge_stack)
+            continue
+
+        if edge_source == "real":
+            raise FileNotFoundError(
+                f"real edge GT not found for split={split_name} sample={sample_id} under {edge_root}"
+            )
+
+        derived_edge = derive_edge_from_segmentation(load_segmentation_mask(seg_src))
+        write_edge_targets(edge_dst_file, edge_eval_dst_file, derived_edge)
 
 
 def main():
     args = parse_args()
     src_root = args.src
     dst_root = args.dst
+
+    if args.edge_source == "real" and args.edge_root is None:
+        raise ValueError("--edge-root is required when --edge-source=real")
+
     ensure_empty_dir(dst_root, args.overwrite)
 
     gt_sets_dir = dst_root / "gt_sets"
@@ -171,15 +363,24 @@ def main():
 
     for split_name in ["train", "val", "test"]:
         ids = split_ids.get(split_name, [])
-        if not ids:
-            continue
-        write_split_file(gt_sets_dir / f"{split_name}.txt", ids)
+        if ids:
+            write_split_file(gt_sets_dir / f"{split_name}.txt", ids)
 
-    for split_name in ["train", "test"]:
+    for split_name in ["train", "val", "test"]:
         ids = split_ids.get(split_name, [])
         if not ids:
             continue
-        prepare_split(split_name, ids, src_root, dst_root)
+        source_split_name = resolve_source_split(src_root, split_name, args.val_from)
+        prepare_split(
+            split_name=split_name,
+            source_split_name=source_split_name,
+            ids=ids,
+            src_root=src_root,
+            dst_root=dst_root,
+            edge_source=args.edge_source,
+            edge_root=args.edge_root,
+            edge_format=args.edge_format,
+        )
 
     print(f"Prepared NYUDv2 dataset at {dst_root}")
 

--- a/tests/test_derive_nyud_edge_from_semseg.py
+++ b/tests/test_derive_nyud_edge_from_semseg.py
@@ -1,0 +1,49 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from scripts.derive_nyud_edge_from_semseg import derive_edges_for_prepared_dataset
+
+
+class DeriveNyudEdgeFromSemsegTest(unittest.TestCase):
+    def test_replace_edge_creates_backup_and_nonzero_edges(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dataset_root = Path(tmp_dir) / "NYUv2_MT"
+            segmentation_dir = dataset_root / "segmentation"
+            edge_dir = dataset_root / "edge"
+            segmentation_dir.mkdir(parents=True)
+            edge_dir.mkdir(parents=True)
+
+            seg = np.array(
+                [
+                    [1, 1, 2, 2],
+                    [1, 1, 2, 2],
+                    [3, 3, 2, 2],
+                    [3, 3, 2, 2],
+                ],
+                dtype=np.uint8,
+            )
+            Image.fromarray(seg).save(segmentation_dir / "00001.png")
+            np.save(edge_dir / "00001.npy", np.zeros((4, 4), dtype=np.float32))
+
+            results = derive_edges_for_prepared_dataset(
+                dataset_root=dataset_root,
+                replace_edge=True,
+                overwrite=True,
+            )
+
+            active_edge_path = dataset_root / "edge" / "00001.npy"
+            backup_edge_path = dataset_root / "edge_zero_backup" / "00001.npy"
+
+            self.assertTrue(active_edge_path.is_file())
+            self.assertTrue(backup_edge_path.is_file())
+            self.assertGreater(np.load(active_edge_path).sum(), 0.0)
+            np.testing.assert_array_equal(np.load(backup_edge_path), np.zeros((4, 4), dtype=np.float32))
+            self.assertEqual(results["num_files"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_edge_metrics.py
+++ b/tests/test_edge_metrics.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+
+from evaluation.edge_metrics import evaluate_edge_predictions
+
+
+class EdgeMetricsTest(unittest.TestCase):
+    def test_perfect_prediction_scores_are_one(self):
+        gt = np.zeros((8, 8), dtype=np.float32)
+        gt[2:6, 4] = 1.0
+        pred = gt.copy()
+
+        results = evaluate_edge_predictions(
+            predictions={"00001": pred},
+            ground_truths={"00001": gt[np.newaxis, ...]},
+            thresholds=[1.0, 0.5],
+        )
+
+        self.assertAlmostEqual(results["odsF"], 1.0, places=6)
+        self.assertAlmostEqual(results["oisF"], 1.0, places=6)
+        self.assertAlmostEqual(results["ap"], 1.0, places=6)
+
+    def test_empty_prediction_has_zero_f_score(self):
+        gt = np.zeros((8, 8), dtype=np.float32)
+        gt[1:7, 3] = 1.0
+        pred = np.zeros_like(gt)
+
+        results = evaluate_edge_predictions(
+            predictions={"00001": pred},
+            ground_truths={"00001": gt[np.newaxis, ...]},
+            thresholds=[0.5],
+        )
+
+        self.assertAlmostEqual(results["odsF"], 0.0, places=6)
+        self.assertAlmostEqual(results["oisF"], 0.0, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prepare_nyudv2.py
+++ b/tests/test_prepare_nyudv2.py
@@ -1,0 +1,76 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from scripts.prepare_nyudv2 import derive_edge_from_segmentation, fuse_edge_annotations, write_edge_targets
+
+
+class PrepareNyudv2Test(unittest.TestCase):
+    def test_derived_edges_stay_on_class_boundary(self):
+        seg = np.array(
+            [
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+            ],
+            dtype=np.int32,
+        )
+
+        edge = derive_edge_from_segmentation(seg)
+
+        self.assertGreater(edge.sum(), 0)
+        self.assertEqual(edge[:, :1].sum(), 0)
+        self.assertEqual(edge[:, 3:].sum(), 0)
+
+    def test_majority_vote_fuses_multi_annotator_edges(self):
+        edge_stack = np.array(
+            [
+                [[0, 1], [0, 0]],
+                [[0, 1], [0, 0]],
+                [[0, 0], [0, 0]],
+            ],
+            dtype=np.float32,
+        )
+
+        fused = fuse_edge_annotations(edge_stack)
+        expected = np.array([[0, 1], [0, 0]], dtype=np.float32)
+        np.testing.assert_array_equal(fused, expected)
+
+    def test_majority_vote_rejects_even_split_ties(self):
+        edge_stack = np.array(
+            [
+                [[0, 1], [0, 0]],
+                [[0, 0], [0, 0]],
+            ],
+            dtype=np.float32,
+        )
+
+        fused = fuse_edge_annotations(edge_stack)
+        expected = np.zeros((2, 2), dtype=np.float32)
+        np.testing.assert_array_equal(fused, expected)
+
+    def test_write_edge_targets_emits_edge_eval_for_multi_gt(self):
+        edge_stack = np.array(
+            [
+                [[0, 1], [0, 0]],
+                [[0, 1], [0, 0]],
+            ],
+            dtype=np.float32,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            edge_dst = tmp_path / "edge" / "00001.npy"
+            edge_eval_dst = tmp_path / "edge_eval" / "00001.npz"
+            write_edge_targets(edge_dst, edge_eval_dst, edge_stack)
+
+            self.assertTrue(edge_dst.is_file())
+            self.assertTrue(edge_eval_dst.is_file())
+            np.testing.assert_array_equal(np.load(edge_dst), np.array([[0, 1], [0, 0]], dtype=np.float32))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary
- swap the zeroed `edge/` data in `D:\04_Data\Dataset\NYUv2_MT` with the segmentation-derived maps while keeping the old data backed up and the remaining dataset untouched
- reconfigure training to resume from the backbone checkpoint with explicit absolute paths, new `edge-derived-rerun` tag, and `--debug-repro-steps 3` so edge stats stay non-zero and eval metrics avoid the degraded `0/1/0` pattern
- keep task losses, weights, and evaluation targets unchanged while relying on the derived edge signals for this rerun

Testing
- Not run (not requested)